### PR TITLE
improve: Change pool rebalance leaf count type to uint8

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -50,11 +50,11 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
     // slowRelayRoot to a SpokePool. The latter two roots, once published to the SpokePool, contain
     // leaves that can be executed on the SpokePool to pay relayers or recipients.
     struct RootBundle {
-        // When root bundle challenge period passes and this root bundle becomes executable.
-        uint64 requestExpirationTimestamp;
         // Number of pool rebalance leaves to execute in the poolRebalanceRoot. After this number
         // of leaves are executed, a new root bundle can be proposed
-        uint64 unclaimedPoolRebalanceLeafCount;
+        uint8 unclaimedPoolRebalanceLeafCount;
+        // When root bundle challenge period passes and this root bundle becomes executable.
+        uint64 requestExpirationTimestamp;
         // Contains leaves instructing this contract to send funds to SpokePools.
         bytes32 poolRebalanceRoot;
         // Relayer refund merkle root to be published to a SpokePool.

--- a/contracts/HubPoolInterface.sol
+++ b/contracts/HubPoolInterface.sol
@@ -40,7 +40,7 @@ interface HubPoolInterface {
 
     function setBond(IERC20 newBondToken, uint256 newBondAmount) external;
 
-    function setLiveness(uint64 newLiveness) external;
+    function setLiveness(uint32 newLiveness) external;
 
     function setIdentifier(bytes32 newIdentifier) external;
 

--- a/test/HubPool.Admin.ts
+++ b/test/HubPool.Admin.ts
@@ -89,7 +89,7 @@ describe("HubPool Admin functions", function () {
     await expect(hubPool.connect(owner).setIdentifier(identifier)).to.be.revertedWith("Identifier not supported");
   });
   it("Set liveness", async function () {
-    const newLiveness = "1000000";
+    const newLiveness = 1000000;
     await hubPool.connect(owner).setLiveness(newLiveness);
     await expect(await hubPool.liveness()).to.equal(newLiveness);
   });
@@ -97,6 +97,6 @@ describe("HubPool Admin functions", function () {
     await expect(hubPool.connect(owner).setLiveness(599)).to.be.revertedWith("Liveness too short");
   });
   it("Only owner can set liveness", async function () {
-    await expect(hubPool.connect(other).setLiveness("1000000")).to.be.reverted;
+    await expect(hubPool.connect(other).setLiveness(1000000)).to.be.reverted;
   });
 });


### PR DESCRIPTION
Max leaf count can only be uint8 to be consistent with size of `RootBundle.claimedBitMap` and is the same size passed into `proposeRootBundle`, so this is likely just fixing a mistake.