### PR TITLE
improve: Add isSlowRelay param to FilledRelay event

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -115,20 +115,6 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         address indexed depositor,
         address recipient
     );
-    event ExecutedSlowRelayRoot(
-        bytes32 indexed relayHash,
-        uint256 amount,
-        uint256 totalFilledAmount,
-        uint256 fillAmount,
-        uint256 indexed originChainId,
-        uint64 relayerFeePct,
-        uint64 realizedLpFeePct,
-        uint32 depositId,
-        address destinationToken,
-        address caller,
-        address indexed depositor,
-        address recipient
-    );
     event RelayedRootBundle(uint32 indexed rootBundleId, bytes32 relayerRefundRoot, bytes32 slowRelayRoot);
     event ExecutedRelayerRefundRoot(
         uint256 amountToReturn,
@@ -624,8 +610,6 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         // funds in all cases.
         uint256 fillAmountPreFees = _fillRelay(relayHash, relayData, relayData.amount, relayerFeePct, true);
 
-        _emitExecutedSlowRelayRoot(relayHash, fillAmountPreFees, relayData);
-
         // Note: Set repayment chain ID to 0 to indicate that there is no repayment to be made. The off-chain data
         // worker can use repaymentChainId=0 as a signal to ignore such relays for refunds.
         _emitFillRelay(relayHash, fillAmountPreFees, 0, relayerFeePct, relayData);
@@ -800,27 +784,6 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
             repaymentChainId,
             relayData.originChainId,
             relayerFeePct,
-            relayData.realizedLpFeePct,
-            relayData.depositId,
-            relayData.destinationToken,
-            msg.sender,
-            relayData.depositor,
-            relayData.recipient
-        );
-    }
-
-    function _emitExecutedSlowRelayRoot(
-        bytes32 relayHash,
-        uint256 fillAmount,
-        RelayData memory relayData
-    ) internal {
-        emit ExecutedSlowRelayRoot(
-            relayHash,
-            relayData.amount,
-            relayFills[relayHash],
-            fillAmount,
-            relayData.originChainId,
-            relayData.relayerFeePct,
             relayData.realizedLpFeePct,
             relayData.depositId,
             relayData.destinationToken,

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -45,7 +45,8 @@ describe("SpokePool Relayer Logic", async function () {
         relayData.destinationToken,
         relayer.address,
         relayData.depositor,
-        relayData.recipient
+        relayData.recipient,
+        false
       );
 
     // The collateral should have transferred from relayer to recipient.

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -101,44 +101,6 @@ describe("SpokePool Slow Relay Logic", async function () {
     );
   });
 
-  it("Simple SlowRelay ERC20 ExecutedSlowRelayRoot event", async function () {
-    const relay = relays.find((relay) => relay.destinationToken === destErc20.address)!;
-
-    await expect(
-      spokePool
-        .connect(relayer)
-        .executeSlowRelayRoot(
-          ...getExecuteSlowRelayParams(
-            depositor.address,
-            recipient.address,
-            destErc20.address,
-            consts.amountToRelay,
-            consts.originChainId,
-            consts.realizedLpFeePct,
-            consts.depositRelayerFeePct,
-            consts.firstDepositId,
-            0,
-            tree.getHexProof(relays.find((relay) => relay.destinationToken === destErc20.address)!)
-          )
-        )
-    )
-      .to.emit(spokePool, "ExecutedSlowRelayRoot")
-      .withArgs(
-        tree.hashFn(relay),
-        consts.amountToRelay,
-        consts.amountToRelay,
-        consts.amountToRelay,
-        consts.originChainId,
-        consts.depositRelayerFeePct,
-        consts.realizedLpFeePct,
-        consts.firstDepositId,
-        destErc20.address,
-        relayer.address,
-        depositor.address,
-        recipient.address
-      );
-  });
-
   it("Simple SlowRelay ERC20 FilledRelay event", async function () {
     const relay = relays.find((relay) => relay.destinationToken === destErc20.address)!;
 

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -136,7 +136,8 @@ describe("SpokePool Slow Relay Logic", async function () {
         destErc20.address,
         relayer.address,
         depositor.address,
-        recipient.address
+        recipient.address,
+        true
       );
   });
 


### PR DESCRIPTION
To reduce expected client event queries, overload the `FilledRelay` event to indicate both Slow and Fast relays. Add an `isSlowRelay` param to the event to clearly indicate whether a relay is slow or not. Currently the `repaymentChainId` is also set to 0 to indicate a slow relay but this PR allows for the possibility for the slow relayer to indicate a chain to be repaid on.