### PR TITLE
feat: add emergency admin functions

### DIFF
--- a/contracts/HubPoolInterface.sol
+++ b/contracts/HubPoolInterface.sol
@@ -34,6 +34,10 @@ interface HubPoolInterface {
         address[] l1Tokens;
     }
 
+    function setPaused(bool pause) external;
+
+    function emergencyDeleteProposal() external;
+
     function relaySpokePoolAdminFunction(uint256 chainId, bytes memory functionData) external;
 
     function setProtocolFeeCapture(address newProtocolFeeCaptureAddress, uint256 newProtocolFeeCapturePct) external;


### PR DESCRIPTION
This adds a pause and delete function to allow the governance system to pause proposals/executions and to delete an active proposal.

Working on tests.