### PR TITLE
improve: Simplify ancillary data

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -753,10 +753,13 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
      * @notice Returns ancillary data containing the minimum data necessary that voters can use to identify
      * a root bundle proposal to validate its correctness.
      * @dev The root bundle that is being disputed was the most recently proposed one with a block number less than
-     * or equal to the dispute block time. All of this root bundles data can be found in the ProposeRootBundle event
+     * or equal to the dispute block time. All of this root bundle data can be found in the ProposeRootBundle event
      * params. Moreover, the optimistic oracle will stamp the requester's address (i.e. this contract address) meaning
      * that ancillary data for a dispute originating from another HubPool will always be distinct from a dispute
      * originating from this HubPool.
+     * @dev Since bundleEvaluationNumbers for a root bundle proposal are not stored on-chain, DVM voters will always
+     * have to look up the ProposeRootBundle event to evaluate a dispute, therefore there is no point emitting extra
+     * data in this ancillary data that is already included in the ProposeRootBundle event.
      * @return ancillaryData Ancillary data that can be decoded into UTF8.
      */
     function getRootBundleProposalAncillaryData() public view override returns (bytes memory ancillaryData) {

--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -750,43 +750,17 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
     }
 
     /**
-     * @notice Returns ancillary data containing all relevant root bundle data that voters can format into UTF8 and
-     * use to determine if the root bundle proposal is valid.
+     * @notice Returns ancillary data containing the minimum data necessary that voters can use to identify
+     * a root bundle proposal to validate its correctness.
+     * @dev The root bundle that is being disputed was the most recently proposed one with a block number less than
+     * or equal to the dispute block time. All of this root bundles data can be found in the ProposeRootBundle event
+     * params. Moreover, the optimistic oracle will stamp the requester's address (i.e. this contract address) meaning
+     * that ancillary data for a dispute originating from another HubPool will always be distinct from a dispute
+     * originating from this HubPool.
      * @return ancillaryData Ancillary data that can be decoded into UTF8.
      */
     function getRootBundleProposalAncillaryData() public view override returns (bytes memory ancillaryData) {
-        ancillaryData = AncillaryData.appendKeyValueUint(
-            "",
-            "requestExpirationTimestamp",
-            rootBundleProposal.requestExpirationTimestamp
-        );
-
-        ancillaryData = AncillaryData.appendKeyValueUint(
-            ancillaryData,
-            "unclaimedPoolRebalanceLeafCount",
-            rootBundleProposal.unclaimedPoolRebalanceLeafCount
-        );
-        ancillaryData = AncillaryData.appendKeyValueBytes32(
-            ancillaryData,
-            "poolRebalanceRoot",
-            rootBundleProposal.poolRebalanceRoot
-        );
-        ancillaryData = AncillaryData.appendKeyValueBytes32(
-            ancillaryData,
-            "relayerRefundRoot",
-            rootBundleProposal.relayerRefundRoot
-        );
-        ancillaryData = AncillaryData.appendKeyValueBytes32(
-            ancillaryData,
-            "slowRelayRoot",
-            rootBundleProposal.slowRelayRoot
-        );
-        ancillaryData = AncillaryData.appendKeyValueUint(
-            ancillaryData,
-            "claimedBitMap",
-            rootBundleProposal.claimedBitMap
-        );
-        ancillaryData = AncillaryData.appendKeyValueAddress(ancillaryData, "proposer", rootBundleProposal.proposer);
+        return "";
     }
 
     /**

--- a/test/HubPool.DisputeRootBundle.ts
+++ b/test/HubPool.DisputeRootBundle.ts
@@ -3,13 +3,13 @@ import { SignerWithAddress, seedWallet, expect, Contract, ethers } from "./utils
 import * as consts from "./constants";
 import { hubPoolFixture, enableTokensForLP } from "./fixtures/HubPool.Fixture";
 
-let hubPool: Contract, weth: Contract, optimisticOracle: Contract, store: Contract;
+let hubPool: Contract, weth: Contract, optimisticOracle: Contract, store: Contract, mockOracle: Contract;
 let owner: SignerWithAddress, dataWorker: SignerWithAddress, liquidityProvider: SignerWithAddress;
 
 describe("HubPool Root Bundle Dispute", function () {
   beforeEach(async function () {
     [owner, dataWorker, liquidityProvider] = await ethers.getSigners();
-    ({ weth, hubPool, optimisticOracle, store } = await hubPoolFixture());
+    ({ weth, hubPool, optimisticOracle, store, mockOracle } = await hubPoolFixture());
     await enableTokensForLP(owner, hubPool, weth, [weth]);
 
     await seedWallet(dataWorker, [], weth, consts.totalBond.mul(2));
@@ -48,22 +48,17 @@ describe("HubPool Root Bundle Dispute", function () {
     expect(rootBundle.claimedBitMap).to.equal(0); // no claims yet so everything should be marked at 0.
     expect(rootBundle.proposer).to.equal(consts.zeroAddress);
 
+    // HubPool should use `getRootBundleProposalAncillaryData()` return value as the ancillary data that it sends
+    // to the oracle, and the oracle should stamp the hub pool's address.
+    const priceRequestAddedEvent = (await mockOracle.queryFilter(mockOracle.filters.PriceRequestAdded()))[0].args;
     const priceProposalEvent = (await optimisticOracle.queryFilter(optimisticOracle.filters.ProposePrice()))[0].args;
 
     expect(priceProposalEvent?.requester).to.equal(hubPool.address);
     expect(priceProposalEvent?.identifier).to.equal(consts.identifier);
     expect(priceProposalEvent?.ancillaryData).to.equal(preCallAncillaryData);
 
-    const parsedAncillaryData = parseAncillaryData(priceProposalEvent?.ancillaryData);
-    expect(parsedAncillaryData?.requestExpirationTimestamp).to.equal(
-      proposalTime.add(consts.refundProposalLiveness).toNumber()
-    );
-    expect(parsedAncillaryData?.unclaimedPoolRebalanceLeafCount).to.equal(consts.mockPoolRebalanceLeafCount);
-    expect("0x" + parsedAncillaryData?.poolRebalanceRoot).to.equal(consts.mockPoolRebalanceRoot);
-    expect("0x" + parsedAncillaryData?.relayerRefundRoot).to.equal(consts.mockRelayerRefundRoot);
-    expect("0x" + parsedAncillaryData?.slowRelayRoot).to.equal(consts.mockSlowRelayRoot);
-    expect(parsedAncillaryData?.claimedBitMap).to.equal(0);
-    expect(ethers.utils.getAddress("0x" + parsedAncillaryData?.proposer)).to.equal(dataWorker.address);
+    const parsedAncillaryData = parseAncillaryData(priceRequestAddedEvent?.ancillaryData);
+    expect(ethers.utils.getAddress("0x" + parsedAncillaryData?.ooRequester)).to.equal(hubPool.address);
   });
   it("Can not dispute after proposal liveness", async function () {
     await weth.connect(dataWorker).approve(hubPool.address, consts.totalBond.mul(2));

--- a/test/fixtures/UmaEcosystem.Fixture.ts
+++ b/test/fixtures/UmaEcosystem.Fixture.ts
@@ -31,7 +31,7 @@ export const umaEcosystemFixture = hre.deployments.createFixture(async ({ ethers
   // Set up other required UMA ecosystem components.
   await identifierWhitelist.addSupportedIdentifier(identifier);
 
-  return { timer, finder, collateralWhitelist, identifierWhitelist, store, optimisticOracle };
+  return { timer, finder, collateralWhitelist, identifierWhitelist, store, optimisticOracle, mockOracle };
 });
 
 module.exports.tags = ["UmaEcosystem"];


### PR DESCRIPTION
Root bundle data can be grabbed deterministically by looking up the latest `ProposeRootBundle` event before the `DisputeRootBundle` event, so some of the ancillary data currently emitted by the HubPool is redundant.

The reason why we assume that voters will have to fetch a `ProposeRootBundle` event is that  the root bundle's `blockEvaluationNumbers` are not stored on-chain. If they were stored on-chain, we could emit all of the data necessary to evaluate a dispute in the ancillary data. But since `blockEvaluationNumbers` are not stored-onchain, voters will have to look up the `ProposeRootBundle` event regardless and therefore we should not expend gas emitting data already included in that event.