### PR TITLE
fix: [L05] Enabling token for Liquidity provisioning should not reset lastLpFeeUpdate

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -411,14 +411,15 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
      * @param l1Token Token to provide liquidity for.
      */
     function enableL1TokenForLiquidityProvision(address l1Token) public override onlyOwner nonReentrant {
-        // The reason we revert if this L1 token is already enabled is so that the LpFeeUpdate timestamp is not
-        // reset unnecessarily, as this would cause any LP fees that have accrued since the last timestamp to be lost.
-        require(!pooledTokens[l1Token].isEnabled, "L1 token already enabled");
-        if (pooledTokens[l1Token].lpToken == address(0))
+        // If token is being enabled for the first time, create a new LP token and set the timestamp once. We don't
+        // want to ever reset this timestamp otherwise fees that have accrued will be lost since the last update. This
+        // could happen for example if an L1 token is enabled, disabled, and then enabled again.
+        if (pooledTokens[l1Token].lpToken == address(0)) {
             pooledTokens[l1Token].lpToken = lpTokenFactory.createLpToken(l1Token);
+            pooledTokens[l1Token].lastLpFeeUpdate = uint32(getCurrentTime());
+        }
 
         pooledTokens[l1Token].isEnabled = true;
-        pooledTokens[l1Token].lastLpFeeUpdate = uint32(getCurrentTime());
 
         emit L1TokenEnabledForLiquidityProvision(l1Token, pooledTokens[l1Token].lpToken);
     }

--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -411,6 +411,9 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
      * @param l1Token Token to provide liquidity for.
      */
     function enableL1TokenForLiquidityProvision(address l1Token) public override onlyOwner nonReentrant {
+        // The reason we revert if this L1 token is already enabled is so that the LpFeeUpdate timestamp is not
+        // reset unnecessarily, as this would cause any LP fees that have accrued since the last timestamp to be lost.
+        require(!pooledTokens[l1Token].isEnabled, "L1 token already enabled");
         if (pooledTokens[l1Token].lpToken == address(0))
             pooledTokens[l1Token].lpToken = lpTokenFactory.createLpToken(l1Token);
 

--- a/test/HubPool.Admin.ts
+++ b/test/HubPool.Admin.ts
@@ -13,7 +13,7 @@ let hubPool: Contract,
   identifierWhitelist: Contract;
 let owner: SignerWithAddress, other: SignerWithAddress;
 
-describe.only("HubPool Admin functions", function () {
+describe("HubPool Admin functions", function () {
   beforeEach(async function () {
     [owner, other] = await ethers.getSigners();
     ({ weth, hubPool, usdc, mockAdapter, mockSpoke, identifierWhitelist } = await hubPoolFixture());


### PR DESCRIPTION
Issue:
- [L05] Liquidity provisioning can skew fee assessments
    - In the HubPool contract the enableL1TokenForLiquidityProvision function allows the contract
owner to enable an l1token to be added to the protocol for liquidity pooling.
    - This is allowed even if the l1token is already currently enabled.
    - As this function also sets the lastLpFeeUpdate variable to the then-current block.timestamp,
enabling an already enabled token will skip over the period of time since lastLpFeeUpdate was last
set. As a result, any LP fees that should have been assessed for that time period would simply never be
assessed.
    - Consider reverting if this function is called for an l1token that is already enabled.

Solution:
- Only set `lastLpFeeUpdate` upon first enabling