### PR TITLE
improve: [L07] Prevent unexpected proposal cancellations by constraining bond size

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -566,11 +566,6 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
         // technically valid but not useful. This could also potentially be enforced at the UMIP-level.
         require(poolRebalanceLeafCount > 0, "Bundle must have at least 1 leaf");
 
-        // Check that bond amount is > final fee, otherwise this root bundle will always get deleted
-        // on a dispute. This isn't an exploitable situation but is unexpected potentially for disputers, and best to
-        // avoid upfront.
-        require(bondAmount > _getBondTokenFinalFee(), "bond amount must be > final fee");
-
         uint32 requestExpirationTimestamp = uint32(getCurrentTime()) + liveness;
 
         delete rootBundleProposal; // Only one bundle of roots can be executed at a time.

--- a/test/HubPool.Admin.ts
+++ b/test/HubPool.Admin.ts
@@ -94,6 +94,9 @@ describe("HubPool Admin functions", function () {
     const newBondAmount = ethers.utils.parseUnits("1000", 6); // set to 1000e6, i.e 1000 USDC.
     await hubPool.setBond(usdc.address, newBondAmount);
 
+    // Can't set bond to 0.
+    await expect(hubPool.setBond(usdc.address, "0")).to.be.revertedWith("bond equal to final fee");
+
     expect(await hubPool.callStatic.bondToken()).to.equal(usdc.address); // New Address.
     expect(await hubPool.callStatic.bondAmount()).to.equal(newBondAmount.add(finalFeeUsdc)); // New Bond amount.
   });

--- a/test/HubPool.DisputeRootBundle.ts
+++ b/test/HubPool.DisputeRootBundle.ts
@@ -81,7 +81,7 @@ describe("HubPool Root Bundle Dispute", function () {
 
     await expect(hubPool.connect(dataWorker).disputeRootBundle()).to.be.revertedWith("Request passed liveness");
   });
-  it("Increase in final fee triggers cancellation", async function () {
+  it("Setting final fee equal to bond triggers cancellation", async function () {
     await weth.connect(dataWorker).approve(hubPool.address, consts.totalBond.mul(2));
     await hubPool
       .connect(dataWorker)
@@ -93,7 +93,8 @@ describe("HubPool Root Bundle Dispute", function () {
         consts.mockSlowRelayRoot
       );
 
-    await store.setFinalFee(weth.address, { rawValue: consts.finalFee.mul(10) });
+    // Setting the final fee < totalBond should fail this test
+    await store.setFinalFee(weth.address, { rawValue: consts.totalBond });
 
     await expect(() => hubPool.connect(dataWorker).disputeRootBundle()).to.changeTokenBalances(
       weth,

--- a/test/HubPool.ProposeRootBundle.ts
+++ b/test/HubPool.ProposeRootBundle.ts
@@ -28,7 +28,7 @@ describe("HubPool Root Bundle Proposal", function () {
           consts.mockRelayerRefundRoot,
           consts.mockSlowRelayRoot
         )
-    ).to.be.revertedWith("bond amount equal to final fee");
+    ).to.be.revertedWith("bond amount must be > final fee");
 
     await store.setFinalFee(weth.address, { rawValue: consts.totalBond.div(2) });
     await expect(

--- a/test/HubPool.ProposeRootBundle.ts
+++ b/test/HubPool.ProposeRootBundle.ts
@@ -2,12 +2,12 @@ import { SignerWithAddress, seedWallet, expect, Contract, ethers } from "./utils
 import * as consts from "./constants";
 import { hubPoolFixture } from "./fixtures/HubPool.Fixture";
 
-let hubPool: Contract, weth: Contract, store: Contract, dataWorker: SignerWithAddress, owner: SignerWithAddress;
+let hubPool: Contract, weth: Contract, dataWorker: SignerWithAddress, owner: SignerWithAddress;
 
 describe("HubPool Root Bundle Proposal", function () {
   beforeEach(async function () {
     [owner, dataWorker] = await ethers.getSigners();
-    ({ weth, hubPool, store } = await hubPoolFixture());
+    ({ weth, hubPool } = await hubPoolFixture());
     await seedWallet(dataWorker, [], weth, consts.totalBond);
   });
 
@@ -16,21 +16,6 @@ describe("HubPool Root Bundle Proposal", function () {
     await weth.connect(dataWorker).approve(hubPool.address, consts.totalBond);
     const dataWorkerWethBalancerBefore = await weth.callStatic.balanceOf(dataWorker.address);
 
-    // Can't propose when bond is equal to final fee.
-    await store.setFinalFee(weth.address, { rawValue: consts.totalBond });
-    await expect(
-      hubPool
-        .connect(dataWorker)
-        .proposeRootBundle(
-          consts.mockBundleEvaluationBlockNumbers,
-          consts.mockPoolRebalanceLeafCount,
-          consts.mockPoolRebalanceRoot,
-          consts.mockRelayerRefundRoot,
-          consts.mockSlowRelayRoot
-        )
-    ).to.be.revertedWith("bond amount must be > final fee");
-
-    await store.setFinalFee(weth.address, { rawValue: consts.totalBond.div(2) });
     await expect(
       hubPool
         .connect(dataWorker)


### PR DESCRIPTION
Issue:
- [L07] Unexpected proposal cancellation
    - In the HubPool contract during a call to the disputeRootBundle function, if the bondAmount and
finalFee values are the same, then the proposer bond passed to the optimistic oracle is zero.
When this happens, the optimistic oracle unilaterally sets the bond to the finalFee and then attempts
to withdraw bond + final fee.
    - Since the HubPool only sets the allowance for the oracle to bondAmount rather than bondAmount +
finalFee, this transfer will fail and, as a result, the proposal will be cancelled.
    - This means that in the situation where bondAmount and finalFee values are identical, every proposal
will be cancelled. Consider documenting this situation, checking for it explicitly and reverting with an
insightful error message. Additionally, consider trying to avoid the situation by reverting in the setBond
function if the newBondAmount is equal to the finalFee or in the proposeRootBundle function if
bondAmount is equal to the finalFee.

Resolution:
- Cancel proposal quickly if `bond == finalFee` in `disputeRootBundle`
- Prevent setting bond equal to final fee in `setBond` and revert `proposeRootBundle` if `bond == finalFee`