### PR TITLE
feat: [N01] Add source for _executeCall implementation

### DIFF
--- a/contracts/chain-adapters/Ethereum_Adapter.sol
+++ b/contracts/chain-adapters/Ethereum_Adapter.sol
@@ -52,7 +52,7 @@ contract Ethereum_Adapter is AdapterInterface {
         emit TokensRelayed(l1Token, l2Token, amount, to);
     }
 
-    // Note: this snippet of code is copied from Governor.sol.
+    // Note: this snippet of code is copied from Governor.sol. Source: https://github.com/UMAprotocol/protocol/blob/5b37ea818a28479c01e458389a83c3e736306b17/packages/core/contracts/oracle/implementation/Governor.sol#L190-L207
     function _executeCall(address to, bytes memory data) private {
         // Note: this snippet of code is copied from Governor.sol and modified to not include any "value" field.
         // solhint-disable-next-line no-inline-assembly


### PR DESCRIPTION
Issue:
- [N01] Missing link to referenced code
    - Within the Ethereum_Adapter, there is a mention of copying code from "Governor.sol". It appears that
the contract in question is Governor.sol from the UMAprotocol/protocol repository.
    - Since it is a part of a separate repository, and it is possible that the code may change in the future,
consider including a link to the file, including a commit hash, so that it can be easily referenced by
developers and reviewers in the future.﻿
