### PR TITLE
improve: [N07] Document that payable functions cannot be included in MultiCaller functions

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -810,6 +810,10 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
     /**
      * @notice This function allows a caller to load the contract with raw ETH to perform L2 calls. This is needed for arbitrum
      * calls, but may also be needed for others.
+     * @dev This function cannot be included in a multicall transaction call because it is `payable`. A realistic
+     * situation where this might be an issue is if the caller is executing a PoolRebalanceLeaf that needs to relay
+     * messages to Arbitrum. Relaying messages to Arbitrum requires that this contract has an ETH balance, so in this
+     * case the caller would need to pre-load this contract with ETH before multicall-executing the leaf.
      */
     function loadEthForL2Calls() public payable override {}
 


### PR DESCRIPTION
Issue:
- [N07] payable multicall function disallows msg.value
    - The MultiCaller contract is inherited by the HubPool and SpokePool contracts. It provides the public
multiCall function that facilitates calling multiple methods within the same contract with only a single
call.
    - However, although it is designated as a payable function, it disallows any calls that send ETH, ie where
msg.value is not zero.
    - This effectively makes the payable designation moot and the contradictory indications could lead to
confusion.
    - In the context of the HubPool, specifically, relays destined for chains where ETH is required and where
a call to loadEthForL2Calls is therefore necessary, will not be multi-callable.
Consider either explicitly noting this limitation, or removing both the require statement and the
payable designation.﻿

Resolution:
- Document payable functions that would naturally be included in multicall bundles, such as loadEthForL2Calls, this issue.
