### PR TITLE
fix: [N14] Remove unused Adapter events

### DIFF
--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -60,14 +60,6 @@ contract Arbitrum_Adapter is AdapterInterface {
 
     ArbitrumL1ERC20GatewayLike public immutable l1ERC20Gateway;
 
-    event L2GasLimitSet(uint32 newL2GasLimit);
-
-    event L2MaxSubmissionCostSet(uint256 newL2MaxSubmissionCost);
-
-    event L2GasPriceSet(uint256 newL2GasPrice);
-
-    event L2RefundL2AddressSet(address newL2RefundL2Address);
-
     /**
      * @notice Constructs new Adapter.
      * @param _l1ArbitrumInbox Inbox helper contract to send messages to Arbitrum.

--- a/contracts/chain-adapters/Optimism_Adapter.sol
+++ b/contracts/chain-adapters/Optimism_Adapter.sol
@@ -37,8 +37,6 @@ contract Optimism_Adapter is CrossDomainEnabled, AdapterInterface {
     address public immutable snx = 0xC011a73ee8576Fb46F5E1c5751cA3B9Fe0af2a6F;
     address public immutable snxOptimismBridge = 0xCd9D4988C0AE61887B075bA77f08cbFAd2b65068;
 
-    event L2GasLimitSet(uint32 newGasLimit);
-
     /**
      * @notice Constructs new Adapter.
      * @param _l1Weth WETH address on L1.

--- a/contracts/interfaces/AdapterInterface.sol
+++ b/contracts/interfaces/AdapterInterface.sol
@@ -6,8 +6,6 @@ pragma solidity ^0.8.0;
  */
 
 interface AdapterInterface {
-    event HubPoolChanged(address newHubPool);
-
     event MessageRelayed(address target, bytes message);
 
     event TokensRelayed(address l1Token, address l2Token, uint256 amount, address to);


### PR DESCRIPTION
Issue:
- [N14] Unused code
Throughout the codebase, there are instances of unused code. For example:
    - The proposerBondRepaid attribute of the HubPool contract's RootBundle struct is never used.
Consider removing it.
    - The events in the Arbitrum_Adapter contract are never used. As the relevant state variables
are immutable, consider setting all relevant values in the constructor and emitting these events
then. Alternatively, consider adding comments indicating why events are declared but unused.
    - The L2GasLimitSet event in the Optimism_Adapter is never emitted. Consider emitting it in the
constructor, removing it, or adding a comment indicating why it is declared but not used.
    - The HubPoolChanged event is never used.﻿

Resolution:
- proposerBondRepaid was removed in [this PR](https://github.com/across-protocol/contracts-v2/pull/78/files#r823468368)
- All unused adapter events are removed in this PR
