### PR TITLE
fix[N03] Fixed inconsistant token metadata versioning

### DIFF
--- a/contracts/LpTokenFactory.sol
+++ b/contracts/LpTokenFactory.sol
@@ -17,7 +17,7 @@ contract LpTokenFactory is LpTokenFactoryInterface {
      */
     function createLpToken(address l1Token) public returns (address) {
         ExpandedERC20 lpToken = new ExpandedERC20(
-            _append("Across ", IERC20Metadata(l1Token).name(), " LP Token"), // LP Token Name
+            _append("Across V2 ", IERC20Metadata(l1Token).name(), " LP Token"), // LP Token Name
             _append("Av2-", IERC20Metadata(l1Token).symbol(), "-LP"), // LP Token Symbol
             IERC20Metadata(l1Token).decimals() // LP Token Decimals
         );

--- a/test/HubPool.Admin.ts
+++ b/test/HubPool.Admin.ts
@@ -30,7 +30,7 @@ describe("HubPool Admin functions", function () {
 
     const lpToken = await (await getContractFactory("ExpandedERC20", owner)).attach(pooledTokenStruct.lpToken);
     expect(await lpToken.callStatic.symbol()).to.equal("Av2-WETH-LP");
-    expect(await lpToken.callStatic.name()).to.equal("Across Wrapped Ether LP Token");
+    expect(await lpToken.callStatic.name()).to.equal("Across V2 Wrapped Ether LP Token");
   });
   it("Only owner can enable L1 Tokens for liquidity provision", async function () {
     await expect(hubPool.connect(other).enableL1TokenForLiquidityProvision(weth.address)).to.be.reverted;


### PR DESCRIPTION
**Problem:**
In the LpTokenFactory contract, the LP tokens it creates have inconsistent versioning in their
metadata.
While the token symbol is prepended with Av2 (ostensibly for "Across version 2"), the token name is
prepended only with "Across" and no version number.

**Resolution:**
LP token name now contains the version, like the symbol.
