### PR TITLE
fix[N11] Fix Residual privleged roles

### DIFF
--- a/contracts/LpTokenFactory.sol
+++ b/contracts/LpTokenFactory.sol
@@ -23,6 +23,7 @@ contract LpTokenFactory is LpTokenFactoryInterface {
         );
         lpToken.addMinter(msg.sender); // Set the caller as the LP Token's minter.
         lpToken.addBurner(msg.sender); // Set the caller as the LP Token's burner.
+        lpToken.resetOwner(address(0)); // Set the owner of to the 0 address to prevent future role changes.
 
         return address(lpToken);
     }

--- a/contracts/LpTokenFactory.sol
+++ b/contracts/LpTokenFactory.sol
@@ -23,7 +23,7 @@ contract LpTokenFactory is LpTokenFactoryInterface {
         );
         lpToken.addMinter(msg.sender); // Set the caller as the LP Token's minter.
         lpToken.addBurner(msg.sender); // Set the caller as the LP Token's burner.
-        lpToken.resetOwner(address(0)); // Set the owner of to the 0 address to prevent future role changes.
+        lpToken.resetOwner(msg.sender); // Set the caller as the LP Token's owner.
 
         return address(lpToken);
     }

--- a/contracts/LpTokenFactory.sol
+++ b/contracts/LpTokenFactory.sol
@@ -22,7 +22,7 @@ contract LpTokenFactory is LpTokenFactoryInterface {
             IERC20Metadata(l1Token).decimals() // LP Token Decimals
         );
         lpToken.addMinter(msg.sender); // Set the caller as the LP Token's minter.
-        lpToken.addMinter(msg.sender); // Set the caller as the LP Token's burner.
+        lpToken.addBurner(msg.sender); // Set the caller as the LP Token's burner.
 
         return address(lpToken);
     }

--- a/contracts/LpTokenFactory.sol
+++ b/contracts/LpTokenFactory.sol
@@ -21,8 +21,8 @@ contract LpTokenFactory is LpTokenFactoryInterface {
             _append("Av2-", IERC20Metadata(l1Token).symbol(), "-LP"), // LP Token Symbol
             IERC20Metadata(l1Token).decimals() // LP Token Decimals
         );
-        lpToken.addMember(1, msg.sender); // Set this contract as the LP Token's minter.
-        lpToken.addMember(2, msg.sender); // Set this contract as the LP Token's burner.
+        lpToken.addMinter(msg.sender); // Set the caller as the LP Token's minter.
+        lpToken.addMinter(msg.sender); // Set the caller as the LP Token's burner.
 
         return address(lpToken);
     }


### PR DESCRIPTION
**Problem:**

When the LpTokenFactory contract creates an ExpandedERC20 token contract, the factory becomes
the owner of that token contract. The factory then proceeds to assign the minter and burner roles to
the msg.sender. The factory remains the owner.

**Solution:**
Set associated roles and transfer ownership to the HubPool.
