### PR TITLE
fix[N15] Unnecessary import statements

### DIFF
--- a/contracts/Arbitrum_SpokePool.sol
+++ b/contracts/Arbitrum_SpokePool.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "./SpokePool.sol";
-import "./SpokePoolInterface.sol";
 
 interface StandardBridgeLike {
     function outboundTransfer(

--- a/contracts/Ethereum_SpokePool.sol
+++ b/contracts/Ethereum_SpokePool.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "./SpokePool.sol";
-import "./SpokePoolInterface.sol";
 import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**

--- a/contracts/Ethereum_SpokePool.sol
+++ b/contracts/Ethereum_SpokePool.sol
@@ -1,13 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "./interfaces/WETH9.sol";
-
-import "@openzeppelin/contracts/access/Ownable.sol";
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 import "./SpokePool.sol";
 import "./SpokePoolInterface.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
 
 /**
  * @notice Ethereum L1 specific SpokePool. Used on Ethereum L1 to facilitate L2->L1 transfers.

--- a/contracts/HubPoolInterface.sol
+++ b/contracts/HubPoolInterface.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "./interfaces/AdapterInterface.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 /**
  * @notice Concise list of functions in HubPool implementation.

--- a/contracts/MerkleLib.sol
+++ b/contracts/MerkleLib.sol
@@ -1,9 +1,10 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "./SpokePoolInterface.sol";
 import "./HubPoolInterface.sol";
+
+import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 
 /**
  * @notice Library to help with merkle roots, proofs, and claims.

--- a/contracts/Optimism_SpokePool.sol
+++ b/contracts/Optimism_SpokePool.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.8.0;
 
 import "./SpokePool.sol";
 import "./interfaces/WETH9.sol";
-import "./SpokePoolInterface.sol";
 
 import "@eth-optimism/contracts/libraries/bridge/CrossDomainEnabled.sol";
 import "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";

--- a/contracts/Optimism_SpokePool.sol
+++ b/contracts/Optimism_SpokePool.sol
@@ -1,13 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "./SpokePool.sol";
 import "./interfaces/WETH9.sol";
+import "./SpokePoolInterface.sol";
 
 import "@eth-optimism/contracts/libraries/bridge/CrossDomainEnabled.sol";
 import "@eth-optimism/contracts/libraries/constants/Lib_PredeployAddresses.sol";
 import "@eth-optimism/contracts/L2/messaging/IL2ERC20Bridge.sol";
-import "./SpokePool.sol";
-import "./SpokePoolInterface.sol";
 
 /**
  * @notice OVM specific SpokePool. Uses OVM cross-domain-enabled logic to implement admin only access to functions.

--- a/contracts/PolygonTokenBridger.sol
+++ b/contracts/PolygonTokenBridger.sol
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "./Lockable.sol";
 import "./interfaces/WETH9.sol";
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
 // ERC20s (on polygon) compatible with polygon's bridge have a withdraw method.
 interface PolygonIERC20 is IERC20 {

--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -1,12 +1,13 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
+import "./SpokePool.sol";
+import "./PolygonTokenBridger.sol";
 import "./interfaces/WETH9.sol";
+import "./SpokePoolInterface.sol";
+
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
-import "./SpokePool.sol";
-import "./SpokePoolInterface.sol";
-import "./PolygonTokenBridger.sol";
 
 // IFxMessageProcessor represents interface to process messages.
 interface IFxMessageProcessor {

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -3,18 +3,16 @@ pragma solidity ^0.8.0;
 
 import "./MerkleLib.sol";
 import "./interfaces/WETH9.sol";
+import "./Lockable.sol";
+import "./SpokePoolInterface.sol";
 
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 
 import "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
-
 import "@uma/core/contracts/common/implementation/Testable.sol";
 import "@uma/core/contracts/common/implementation/MultiCaller.sol";
-import "./Lockable.sol";
-import "./MerkleLib.sol";
-import "./SpokePoolInterface.sol";
 
 /**
  * @title SpokePool

--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -2,10 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "../interfaces/AdapterInterface.sol";
-import "../interfaces/AdapterInterface.sol";
-import "../interfaces/WETH9.sol";
-
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface ArbitrumL1InboxLike {
     function createRetryableTicket(

--- a/contracts/chain-adapters/Ethereum_Adapter.sol
+++ b/contracts/chain-adapters/Ethereum_Adapter.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.0;
 
 import "../interfaces/AdapterInterface.sol";
-import "../interfaces/WETH9.sol";
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";

--- a/contracts/chain-adapters/Polygon_Adapter.sol
+++ b/contracts/chain-adapters/Polygon_Adapter.sol
@@ -3,10 +3,7 @@ pragma solidity ^0.8.0;
 
 import "../interfaces/AdapterInterface.sol";
 import "../interfaces/WETH9.sol";
-import "../Lockable.sol";
 
-import "@eth-optimism/contracts/libraries/bridge/CrossDomainEnabled.sol";
-import "@eth-optimism/contracts/L1/messaging/IL1StandardBridge.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 

--- a/contracts/interfaces/LpTokenFactoryInterface.sol
+++ b/contracts/interfaces/LpTokenFactoryInterface.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
-import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-
 interface LpTokenFactoryInterface {
     function createLpToken(address l1Token) external returns (address);
 }


### PR DESCRIPTION
**Problem**:
The below list outlines contract import statements that are unnecessary:
The WETH9 and Lockable imports are not used in the Ethereum_Adapter contract.
The CrossDomainEnabled, IL1StandardBridge, and Lockable imports are not used in the
Polygon_Adapter contract.
The WETH9 and IERC20 imports are not used in the Arbitrum_Adapter contract.
The AdapterInterface interface is imported twice in the Arbitrum_Adapter contract.
The WETH9 and SpokePoolInterface imports are not used in the Ethereum_SpokePool contract.
The IERC20 import in the LpTokenFactoryInterface interface is unused.
The MerkleLib is imported twice in the SpokePool contract.

**Solution**
Removed unnecessary imports. I also changed the ordering of some of them to be more consistant (implementation, then interfaces, then external).