### PR TITLE
fix: [L02] Re-add checks that adapter is not 0x0

### DIFF
--- a/test/HubPool.Admin.ts
+++ b/test/HubPool.Admin.ts
@@ -65,14 +65,14 @@ describe("HubPool Admin functions", function () {
     ]);
     await expect(hubPool.connect(other).relaySpokePoolAdminFunction(destinationChainId, functionData)).to.be.reverted;
 
-    // Cannot relay admin function if spoke pool or adapter is set to zero address.
+    // Cannot relay admin function if spoke pool is set to zero address or adapter is set to non contract..
     await hubPool.setCrossChainContracts(destinationChainId, mockAdapter.address, ZERO_ADDRESS);
     await expect(hubPool.relaySpokePoolAdminFunction(destinationChainId, functionData)).to.be.revertedWith(
       "SpokePool not initialized"
     );
-    await hubPool.setCrossChainContracts(destinationChainId, ZERO_ADDRESS, mockSpoke.address);
+    await hubPool.setCrossChainContracts(destinationChainId, randomAddress(), mockSpoke.address);
     await expect(hubPool.relaySpokePoolAdminFunction(destinationChainId, functionData)).to.be.revertedWith(
-      "delegatecall failed"
+      "Adapter not initialized"
     );
     await hubPool.setCrossChainContracts(destinationChainId, mockAdapter.address, mockSpoke.address);
     await expect(hubPool.relaySpokePoolAdminFunction(destinationChainId, functionData))

--- a/test/HubPool.Admin.ts
+++ b/test/HubPool.Admin.ts
@@ -65,9 +65,15 @@ describe("HubPool Admin functions", function () {
     ]);
     await expect(hubPool.connect(other).relaySpokePoolAdminFunction(destinationChainId, functionData)).to.be.reverted;
 
-    // Cannot relay admin function if spoke pool is set to zero address.
+    // Cannot relay admin function if spoke pool or adapter is set to zero address.
     await hubPool.setCrossChainContracts(destinationChainId, mockAdapter.address, ZERO_ADDRESS);
-    await expect(hubPool.relaySpokePoolAdminFunction(destinationChainId, functionData)).to.be.reverted;
+    await expect(hubPool.relaySpokePoolAdminFunction(destinationChainId, functionData)).to.be.revertedWith(
+      "SpokePool not initialized"
+    );
+    await hubPool.setCrossChainContracts(destinationChainId, ZERO_ADDRESS, mockSpoke.address);
+    await expect(hubPool.relaySpokePoolAdminFunction(destinationChainId, functionData)).to.be.revertedWith(
+      "delegatecall failed"
+    );
     await hubPool.setCrossChainContracts(destinationChainId, mockAdapter.address, mockSpoke.address);
     await expect(hubPool.relaySpokePoolAdminFunction(destinationChainId, functionData))
       .to.emit(hubPool, "SpokePoolAdminFunctionTriggered")

--- a/test/HubPool.ExecuteRootBundle.ts
+++ b/test/HubPool.ExecuteRootBundle.ts
@@ -166,6 +166,23 @@ describe("HubPool Root Bundle Execution", function () {
     ).to.be.revertedWith("Uninitialized spoke pool");
   });
 
+  it("Reverts if adapter not set for chain ID", async function () {
+    const { leafs, tree } = await constructSimpleTree();
+
+    await hubPool
+      .connect(dataWorker)
+      .proposeRootBundle([3117, 3118], 2, tree.getHexRoot(), consts.mockRelayerRefundRoot, consts.mockSlowRelayRoot);
+
+    // Set adapter to address 0x0
+    await hubPool.setCrossChainContracts(consts.repaymentChainId, ZERO_ADDRESS, mockSpoke.address);
+
+    // Advance time so the request can be executed and check that executing the request reverts.
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + consts.refundProposalLiveness + 1);
+    await expect(
+      hubPool.connect(dataWorker).executeRootBundle(...Object.values(leafs[0]), tree.getHexProof(leafs[0]))
+    ).to.be.revertedWith("delegatecall failed");
+  });
+
   it("Execution rejects leaf claim before liveness passed", async function () {
     const { leafs, tree } = await constructSimpleTree();
     await hubPool

--- a/test/HubPool.ExecuteRootBundle.ts
+++ b/test/HubPool.ExecuteRootBundle.ts
@@ -163,7 +163,7 @@ describe("HubPool Root Bundle Execution", function () {
     await timer.setCurrentTime(Number(await timer.getCurrentTime()) + consts.refundProposalLiveness + 1);
     await expect(
       hubPool.connect(dataWorker).executeRootBundle(...Object.values(leafs[0]), tree.getHexProof(leafs[0]))
-    ).to.be.revertedWith("Uninitialized spoke pool");
+    ).to.be.revertedWith("SpokePool not initialized");
   });
 
   it("Reverts if adapter not set for chain ID", async function () {

--- a/test/HubPool.ExecuteRootBundle.ts
+++ b/test/HubPool.ExecuteRootBundle.ts
@@ -1,4 +1,4 @@
-import { toBNWei, SignerWithAddress, seedWallet, expect, Contract, ethers } from "./utils";
+import { toBNWei, SignerWithAddress, seedWallet, expect, Contract, ethers, randomAddress } from "./utils";
 import * as consts from "./constants";
 import { hubPoolFixture, enableTokensForLP } from "./fixtures/HubPool.Fixture";
 import { buildPoolRebalanceLeafTree, buildPoolRebalanceLeafs } from "./MerkleLib.utils";
@@ -173,14 +173,14 @@ describe("HubPool Root Bundle Execution", function () {
       .connect(dataWorker)
       .proposeRootBundle([3117, 3118], 2, tree.getHexRoot(), consts.mockRelayerRefundRoot, consts.mockSlowRelayRoot);
 
-    // Set adapter to address 0x0
-    await hubPool.setCrossChainContracts(consts.repaymentChainId, ZERO_ADDRESS, mockSpoke.address);
+    // Set adapter to random address.
+    await hubPool.setCrossChainContracts(consts.repaymentChainId, randomAddress(), mockSpoke.address);
 
     // Advance time so the request can be executed and check that executing the request reverts.
     await timer.setCurrentTime(Number(await timer.getCurrentTime()) + consts.refundProposalLiveness + 1);
     await expect(
       hubPool.connect(dataWorker).executeRootBundle(...Object.values(leafs[0]), tree.getHexProof(leafs[0]))
-    ).to.be.revertedWith("delegatecall failed");
+    ).to.be.revertedWith("Adapter not initialized");
   });
 
   it("Execution rejects leaf claim before liveness passed", async function () {


### PR DESCRIPTION
#91 removed checks that `adapter != address(0)` because I erroneously assumed that `address(0).delegatecall` would revert this. This PR re-adds the checks + adds unit tests