### PR TITLE
improve: Remove ancillary data helper function

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -754,6 +754,10 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
         uint32 currentTime = uint32(getCurrentTime());
         require(currentTime <= rootBundleProposal.requestExpirationTimestamp, "Request passed liveness");
 
+        // Request price from OO and dispute it.
+        bytes memory requestAncillaryData = getRootBundleProposalAncillaryData();
+        uint256 finalFee = _getBondTokenFinalFee();
+
         // This method will request a price from the OO and dispute it. Note that we set the ancillary data to
         // the empty string (""). The root bundle that is being disputed was the most recently proposed one with a
         // block number less than or equal to the dispute block time. All of this root bundle data can be found in

--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -755,7 +755,6 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
         require(currentTime <= rootBundleProposal.requestExpirationTimestamp, "Request passed liveness");
 
         // Request price from OO and dispute it.
-        bytes memory requestAncillaryData = getRootBundleProposalAncillaryData();
         uint256 finalFee = _getBondTokenFinalFee();
 
         // This method will request a price from the OO and dispute it. Note that we set the ancillary data to
@@ -774,7 +773,7 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
         // to the final fee, which would mean that the allowance set to the bondAmount would be insufficient and the
         // requestAndProposePriceFor() call would revert. Source: https://github.com/UMAprotocol/protocol/blob/5b37ea818a28479c01e458389a83c3e736306b17/packages/core/contracts/oracle/implementation/SkinnyOptimisticOracle.sol#L321
         if (finalFee >= bondAmount) {
-            _cancelBundle(requestAncillaryData);
+            _cancelBundle();
             return;
         }
 

--- a/contracts/HubPoolInterface.sol
+++ b/contracts/HubPoolInterface.sol
@@ -104,8 +104,6 @@ interface HubPoolInterface {
 
     function claimProtocolFeesCaptured(address l1Token) external;
 
-    function getRootBundleProposalAncillaryData() external view returns (bytes memory ancillaryData);
-
     function setPoolRebalanceRoute(
         uint256 destinationChainId,
         address l1Token,

--- a/test/HubPool.DisputeRootBundle.ts
+++ b/test/HubPool.DisputeRootBundle.ts
@@ -34,8 +34,6 @@ describe("HubPool Root Bundle Dispute", function () {
     const proposalTime = await hubPool.getCurrentTime();
     await hubPool.connect(dataWorker).setCurrentTime(proposalTime.add(15));
 
-    const preCallAncillaryData = await hubPool.getRootBundleProposalAncillaryData();
-
     await hubPool.connect(dataWorker).disputeRootBundle();
 
     // Data should be deleted from the contracts refundRequest struct.
@@ -55,7 +53,7 @@ describe("HubPool Root Bundle Dispute", function () {
 
     expect(priceProposalEvent?.requester).to.equal(hubPool.address);
     expect(priceProposalEvent?.identifier).to.equal(consts.identifier);
-    expect(priceProposalEvent?.ancillaryData).to.equal(preCallAncillaryData);
+    expect(priceProposalEvent?.ancillaryData).to.equal("0x");
 
     const parsedAncillaryData = parseAncillaryData(priceRequestAddedEvent?.ancillaryData);
     expect(ethers.utils.getAddress("0x" + parsedAncillaryData?.ooRequester)).to.equal(hubPool.address);

--- a/test/gas-analytics/HubPool.RootExecution.ts
+++ b/test/gas-analytics/HubPool.RootExecution.ts
@@ -240,7 +240,7 @@ describe("Gas Analytics: HubPool Root Bundle Execution", function () {
 
       // Add leaf to tree that contains enough L1 tokens that we can determine the limit after which the executeRoot
       // will fail due to out of gas.
-      const bigLeaves = buildPoolRebalanceLeafs(
+      const bigLeaves = buildPoolRebalanceLeaves(
         [destinationChainIds[0]],
         [l1TokenAddresses],
         [Array(STRESS_TEST_L1_TOKEN_COUNT).fill(toBNWei("0"))],

--- a/test/gas-analytics/SpokePool.RelayerRefundRootExecution.ts
+++ b/test/gas-analytics/SpokePool.RelayerRefundRootExecution.ts
@@ -269,7 +269,7 @@ describe("Gas Analytics: SpokePool Relayer Refund Root Execution", function () {
       await seedContract(spokePool, owner, [], weth, toBN(STRESS_TEST_REFUND_COUNT).mul(REFUND_AMOUNT).mul(toBN(10)));
 
       // Create tree with 1 large leaf.
-      const bigLeaves = buildRelayerRefundLeafs(
+      const bigLeaves = buildRelayerRefundLeaves(
         [destinationChainIds[0]],
         [toBNWei("1")], // Set amount to return > 0 to better simulate long execution path of _executeRelayerRefundLeaf
         [weth.address],


### PR DESCRIPTION
Ancillary data is the empty string so we can remove the helper function + reduce emitted event params to save gas. disputeRootBundle gas reduced by ~1000 (0.3%).

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
