### PR TITLE
feat: Added rate model store from across v1

### DIFF
--- a/contracts/RateModelStore.sol
+++ b/contracts/RateModelStore.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import "@uma/core/contracts/common/implementation/MultiCaller.sol";
+import "@openzeppelin/contracts/access/Ownable.sol";
+
+/**
+ * @title Maps rate model objects to L1 token.
+ * @dev This contract is designed to be queried by off-chain relayers that need to compute realized LP fee %'s before
+ * submitting relay transactions to a BridgePool contract. Therefore, this contract does not perform any validation on
+ * the shape of the rate model, which is stored as a string to enable arbitrary data encoding via a stringified JSON
+ * object. This leaves this contract unopionated on the parameters within the rate model, enabling governance to adjust
+ * the structure in the future.
+ */
+contract RateModelStore is Ownable, MultiCaller {
+    mapping(address => string) public l1TokenRateModels;
+
+    event UpdatedRateModel(address indexed l1Token, string rateModel);
+
+    /**
+     * @notice Updates rate model string for L1 token.
+     * @param l1Token the l1 token rate model to update.
+     * @param rateModel the updated rate model.
+     */
+    function updateRateModel(address l1Token, string memory rateModel) external onlyOwner {
+        l1TokenRateModels[l1Token] = rateModel;
+        emit UpdatedRateModel(l1Token, rateModel);
+    }
+}


### PR DESCRIPTION
We need the rate model store from across V1. This PR simply copy and pastes this contract with no changes other than one modification to an import.
