### PR TITLE
improve: Change indexed event params to assist offchain dataworker

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -149,9 +149,9 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
     event ProposeRootBundle(
         uint32 challengePeriodEndTimestamp,
         uint64 poolRebalanceLeafCount,
-        uint256[] bundleEvaluationBlockNumbers,
+        uint256[] indexed bundleEvaluationBlockNumbers,
         bytes32 indexed poolRebalanceRoot,
-        bytes32 indexed relayerRefundRoot,
+        bytes32 relayerRefundRoot,
         bytes32 slowRelayRoot,
         address indexed proposer
     );

--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -149,9 +149,9 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
     event ProposeRootBundle(
         uint32 challengePeriodEndTimestamp,
         uint64 poolRebalanceLeafCount,
-        uint256[] indexed bundleEvaluationBlockNumbers,
+        uint256[] bundleEvaluationBlockNumbers,
         bytes32 indexed poolRebalanceRoot,
-        bytes32 relayerRefundRoot,
+        bytes32 indexed relayerRefundRoot,
         bytes32 slowRelayRoot,
         address indexed proposer
     );

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -98,7 +98,11 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         address recipient,
         bool isSlowRelay
     );
-    event RelayedRootBundle(uint32 indexed rootBundleId, bytes32 relayerRefundRoot, bytes32 slowRelayRoot);
+    event RelayedRootBundle(
+        uint32 indexed rootBundleId,
+        bytes32 indexed relayerRefundRoot,
+        bytes32 indexed slowRelayRoot
+    );
     event ExecutedRelayerRefundRoot(
         uint256 amountToReturn,
         uint256 indexed chainId,


### PR DESCRIPTION
Dataworker will compute roots for a given bundle block range and look up `SpokePool.RelayedRootBundle` events with matching roots, so we should index on those roots.

Additionally, the HubPool's `ProposeRootBundle` event doesn't need to index any of the root hashes. If anything, it should index the `bundleBlockRange` which is the key for the dataworker to reconstruct roots, but even this might be unneccessary.