### PR TITLE
improve: Add appliedRelayerFeePct to FillRelay event

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -82,7 +82,6 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         bytes depositorSignature
     );
     event FilledRelay(
-        bytes32 indexed relayHash,
         uint256 amount,
         uint256 totalFilledAmount,
         uint256 fillAmount,
@@ -90,6 +89,7 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         uint256 originChainId,
         uint256 destinationChainId,
         uint64 relayerFeePct,
+        uint64 appliedRelayerFeePct,
         uint64 realizedLpFeePct,
         uint32 depositId,
         address destinationToken,
@@ -795,19 +795,19 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         bytes32 relayHash,
         uint256 fillAmount,
         uint256 repaymentChainId,
-        uint64 relayerFeePct,
+        uint64 appliedRelayerFeePct,
         RelayData memory relayData,
         bool isSlowRelay
     ) internal {
         emit FilledRelay(
-            relayHash,
             relayData.amount,
             relayFills[relayHash],
             fillAmount,
             repaymentChainId,
             relayData.originChainId,
             relayData.destinationChainId,
-            relayerFeePct,
+            relayData.relayerFeePct,
+            appliedRelayerFeePct,
             relayData.realizedLpFeePct,
             relayData.depositId,
             relayData.destinationToken,

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -34,13 +34,13 @@ describe("SpokePool Relayer Logic", async function () {
     await expect(spokePool.connect(relayer).fillRelay(...getFillRelayParams(relayData, consts.amountToRelay)))
       .to.emit(spokePool, "FilledRelay")
       .withArgs(
-        relayHash,
         relayData.amount,
         consts.amountToRelayPreFees,
         consts.amountToRelayPreFees,
         consts.repaymentChainId,
         toBN(relayData.originChainId),
         toBN(relayData.destinationChainId),
+        relayData.relayerFeePct,
         relayData.relayerFeePct,
         relayData.realizedLpFeePct,
         toBN(relayData.depositId),
@@ -243,10 +243,30 @@ describe("SpokePool Relayer Logic", async function () {
       relayData.originChainId,
       depositor
     );
-    await spokePool
-      .connect(relayer)
-      .fillRelayWithUpdatedFee(
-        ...getFillRelayUpdatedFeeParams(relayData, consts.amountToRelay, consts.modifiedRelayerFeePct, signature)
+    await expect(
+      spokePool
+        .connect(relayer)
+        .fillRelayWithUpdatedFee(
+          ...getFillRelayUpdatedFeeParams(relayData, consts.amountToRelay, consts.modifiedRelayerFeePct, signature)
+        )
+    )
+      .to.emit(spokePool, "FilledRelay")
+      .withArgs(
+        relayData.amount,
+        consts.amountToRelayPreModifiedFees,
+        consts.amountToRelayPreModifiedFees,
+        consts.repaymentChainId,
+        toBN(relayData.originChainId),
+        toBN(relayData.destinationChainId),
+        relayData.relayerFeePct,
+        consts.modifiedRelayerFeePct, // Applied relayer fee % should be diff from original fee %.
+        relayData.realizedLpFeePct,
+        toBN(relayData.depositId),
+        relayData.destinationToken,
+        relayer.address,
+        relayData.depositor,
+        relayData.recipient,
+        false
       );
 
     // The collateral should have transferred from relayer to recipient.


### PR DESCRIPTION
Emitting both the original and the updated `relayerFeePct` allows off-chain clients to distinguish between correctly and incorrectly sped up `fillRelay` calls with updated relayer fee %'s. Currently, the client has no way to determine if a `FillRelay` event emitted by a speed up relay (i.e. calling `fillRelayWithUpdatedFee`) was a valid fill or not. 

The current exploit would be to call `fillRelay` for a `deposit` with ALL of the correct params except for `relayerFeePct`, which the attacker would set to something lower than expected like `0`. Clients would not be able to easily detect if this modified `relayerFeePct=0` came from a correct `fillRelayWithUpdatedFee` call.