### PR TITLE
fix:M03 Move to using address.sendValue over the transfer pattern when sending eth

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -478,7 +478,7 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
 
         if (sendEth) {
             weth.withdraw(l1TokensToReturn);
-            payable(msg.sender).transfer(l1TokensToReturn); // This will revert if the caller is a contract that does not implement a fallback function.
+            Address.sendValue(payable(msg.sender), l1TokensToReturn); // This will revert if the caller is a contract that does not implement a fallback function.
         } else {
             IERC20(address(l1Token)).safeTransfer(msg.sender, l1TokensToReturn);
         }


### PR DESCRIPTION
OZ points out that using the `transfer` pattern, introduced in PR: https://github.com/across-protocol/contracts-v2/pull/90 is not optimal as if the target of the eth needs more than 2300 gas the tx will revert. This PR changes this to use the `Address.sendValue` function, which uses the `.call` pattern under the hood to address this.