### PR TITLE
fix: Change mentions of EIP191 --> EIP1271

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -310,7 +310,7 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
      * @param depositId Deposit to update fee for that originated in this contract.
      * @param depositorSignature Signed message containing the depositor address, this contract chain ID, the updated
      * relayer fee %, and the deposit ID. This signature is produced by signing a hash of data according to the
-     * EIP-191 standard. See more in the _verifyUpdateRelayerFeeMessage() comments.
+     * EIP-1271 standard. See more in the _verifyUpdateRelayerFeeMessage() comments.
      */
     function speedUpDeposit(
         address depositor,
@@ -685,7 +685,7 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         bytes32 ethSignedMessageHash,
         bytes memory depositorSignature
     ) internal view virtual {
-        // Note: We purposefully do not support EIP-191 signatures (meaning that multisigs and smart contract wallets
+        // Note: We purposefully do not support EIP-1271 signatures (meaning that multisigs and smart contract wallets
         // like Argent are not supported) because of the possibility that a multisig that signed a message on the origin
         // chain does not have a parallel on this destination chain.
         require(depositor == ECDSA.recover(ethSignedMessageHash, depositorSignature), "invalid signature");


### PR DESCRIPTION
EIP1271 is mistakenly referred to as EIP191 in the contracts﻿
