### PR TITLE
fix: Change event param type to match variable

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -148,7 +148,7 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
     );
     event ProposeRootBundle(
         uint32 challengePeriodEndTimestamp,
-        uint64 poolRebalanceLeafCount,
+        uint8 poolRebalanceLeafCount,
         uint256[] bundleEvaluationBlockNumbers,
         bytes32 indexed poolRebalanceRoot,
         bytes32 indexed relayerRefundRoot,


### PR DESCRIPTION
`poolRebalanceLeafCount` is `uint8` in the contract but not the same in the event emitted.