### PR TITLE
improve: Rename ConfigStore => AcrossConfigStore

### DIFF
--- a/contracts/AcrossConfigStore.sol
+++ b/contracts/AcrossConfigStore.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts/access/Ownable.sol";
  * @dev This contract should not perform any validation on the setting values and should be owned by the governance
  * system of the full contract suite..
  */
-contract ConfigStore is Ownable, MultiCaller {
+contract AcrossConfigStore is Ownable, MultiCaller {
     // General dictionary where admin can associate variables with specific L1 tokens, like the Rate Model and Token
     // Transfer Thresholds.
     mapping(address => string) public l1TokenConfig;

--- a/test/ConfigStore.ts
+++ b/test/ConfigStore.ts
@@ -7,7 +7,7 @@ let owner: SignerWithAddress, other: SignerWithAddress;
 describe("Config Store", function () {
   beforeEach(async function () {
     [owner, other] = await ethers.getSigners();
-    configStore = await (await getContractFactory("ConfigStore", owner)).deploy();
+    configStore = await (await getContractFactory("AcrossConfigStore", owner)).deploy();
   });
 
   it("Updating token config", async function () {


### PR DESCRIPTION
Avoids inconvenient clash with `ConfigStore` in `@uma/core/contracts/financial-templates/perpetual-multiparty`