### PR TITLE
improve: Add EMPTY_ROOT constant and isEmpty functions to MerkleRoot utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "0.0.52",
+  "version": "0.0.53",
   "author": "UMA Team",
   "license": "AGPL-3.0",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "0.0.49",
+  "version": "0.0.52",
   "author": "UMA Team",
   "license": "AGPL-3.0",
   "repository": {

--- a/test/MerkleLib.Proofs.ts
+++ b/test/MerkleLib.Proofs.ts
@@ -1,6 +1,6 @@
 import { PoolRebalanceLeaf, RelayerRefundLeaf } from "./MerkleLib.utils";
 import { merkleLibFixture } from "./fixtures/MerkleLib.Fixture";
-import { MerkleTree } from "../utils/MerkleTree";
+import { MerkleTree, EMPTY_MERKLE_ROOT } from "../utils/MerkleTree";
 import { expect, randomBigNumber, randomAddress, getParamType, defaultAbiCoder } from "./utils";
 import { keccak256, Contract, BigNumber } from "./utils";
 
@@ -11,6 +11,16 @@ describe("MerkleLib Proofs", async function () {
     ({ merkleLibTest } = await merkleLibFixture());
   });
 
+  it("Empty tree", async function () {
+    const paramType = await getParamType("MerkleLibTest", "verifyPoolRebalance", "rebalance");
+    const hashFn = (input: PoolRebalanceLeaf) => keccak256(defaultAbiCoder.encode([paramType!], [input]));
+
+    // Can construct empty tree without error.
+    const merkleTree = new MerkleTree<PoolRebalanceLeaf>([], hashFn);
+
+    // Returns hardcoded root for empty tree.
+    expect(merkleTree.getHexRoot()).to.equal(EMPTY_MERKLE_ROOT);
+  });
   it("PoolRebalanceLeaf Proof", async function () {
     const poolRebalanceLeaves: PoolRebalanceLeaf[] = [];
     const numRebalances = 101;

--- a/utils/MerkleTree.ts
+++ b/utils/MerkleTree.ts
@@ -2,9 +2,8 @@
 // https://github.com/Uniswap/merkle-distributor/blob/master/src/merkle-tree.ts with some added convenience methods
 // to take the leaves and conversion functions, so the user never has to work with buffers.
 import { bufferToHex, keccak256 } from "ethereumjs-util";
-import { runInThisContext } from "vm";
 
-export const EMPTY_MERKLE_ROOT = "0x";
+export const EMPTY_MERKLE_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000";
 export class MerkleTree<T> {
   private readonly elements: Buffer[];
   private readonly bufferElementPositionIndex: { [hexElement: string]: number };
@@ -67,11 +66,11 @@ export class MerkleTree<T> {
   }
 
   getRoot(): Buffer {
-    if (this.isEmpty()) return Buffer.from(EMPTY_MERKLE_ROOT, "hex");
     return this.layers[this.layers.length - 1][0];
   }
 
   getHexRoot(): string {
+    if (this.isEmpty()) return EMPTY_MERKLE_ROOT;
     return bufferToHex(this.getRoot());
   }
 

--- a/utils/MerkleTree.ts
+++ b/utils/MerkleTree.ts
@@ -68,6 +68,7 @@ export class MerkleTree<T> {
   }
 
   getRoot(): Buffer {
+    if (this.isEmpty()) return Buffer.from(EMPTY_MERKLE_ROOT, "hex");
     return this.layers[this.layers.length - 1][0];
   }
 

--- a/utils/MerkleTree.ts
+++ b/utils/MerkleTree.ts
@@ -2,8 +2,9 @@
 // https://github.com/Uniswap/merkle-distributor/blob/master/src/merkle-tree.ts with some added convenience methods
 // to take the leaves and conversion functions, so the user never has to work with buffers.
 import { bufferToHex, keccak256 } from "ethereumjs-util";
+import { runInThisContext } from "vm";
 
-export const EMPTY_MERKLE_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000";
+export const EMPTY_MERKLE_ROOT = "0x";
 export class MerkleTree<T> {
   private readonly elements: Buffer[];
   private readonly bufferElementPositionIndex: { [hexElement: string]: number };
@@ -30,11 +31,9 @@ export class MerkleTree<T> {
   }
 
   getLayers(elements: Buffer[]): Buffer[][] {
-    if (elements.length === 0) {
-      throw new Error("empty tree");
-    }
+    const layers: Buffer[][] = [];
+    if (elements.length === 0) return layers;
 
-    const layers = [];
     layers.push(elements);
 
     // Get next layer until we reach the root

--- a/utils/MerkleTree.ts
+++ b/utils/MerkleTree.ts
@@ -3,6 +3,7 @@
 // to take the leaves and conversion functions, so the user never has to work with buffers.
 import { bufferToHex, keccak256 } from "ethereumjs-util";
 
+export const EMPTY_MERKLE_ROOT = "0x0000000000000000000000000000000000000000000000000000000000000000";
 export class MerkleTree<T> {
   private readonly elements: Buffer[];
   private readonly bufferElementPositionIndex: { [hexElement: string]: number };
@@ -22,6 +23,10 @@ export class MerkleTree<T> {
 
     // Create layers
     this.layers = this.getLayers(this.elements);
+  }
+
+  isEmpty(): boolean {
+    return this.layers.length === 0;
   }
 
   getLayers(elements: Buffer[]): Buffer[][] {


### PR DESCRIPTION
Clients that import the MekrleLib module should have universal way to detect if tree is empty and handle accordingly.
﻿Signed-off-by: nicholaspai <npai.nyc@gmail.com>
