### PR TITLE
fix: add haircut proposal

### DIFF
--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -176,7 +176,7 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
     }
 
     modifier unpaused() {
-        require(!paused, "Proposal process has been paused");
+        require(!paused, "Contract is paused");
         _;
     }
 
@@ -432,7 +432,7 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
     function haircutReserves(address l1Token, int256 haircutAmount) public onlyOwner nonReentrant {
         // Note that we do not call sync first in this method. The Owner should call this manually before haircutting.
         // This is done in the event sync is reverting due to too low balanced in the contract relative to bond amount.
-        pooledTokens[l1Token].utilizedReserves += haircutAmount;
+        pooledTokens[l1Token].utilizedReserves -= haircutAmount;
     }
 
     /*************************************************

--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -934,15 +934,13 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
         _updateAccumulatedLpFees(pooledToken); // Accumulate all allocated fees from the last time this method was called.
         _sync(l1Token); // Fetch any balance changes due to token bridging finalization and factor them in.
 
-        // ExchangeRate := (liquidReserves + utilizedReserves - undistributedLpFees - haircutReserves) / lpTokenSupply
+        // ExchangeRate := (liquidReserves + utilizedReserves - undistributedLpFees) / lpTokenSupply
         // Both utilizedReserves and undistributedLpFees contain assigned LP fees. UndistributedLpFees is gradually
         // decreased over the smear duration using _updateAccumulatedLpFees. This means that the exchange rate will
         // gradually increase over time as undistributedLpFees goes to zero.
         // utilizedReserves can be negative. If this is the case, then liquidReserves is offset by an equal
         // and opposite size. LiquidReserves + utilizedReserves will always be larger than undistributedLpFees so this
         // int will always be positive so there is no risk in underflow in type casting in the return line.
-        // haircutReserves will be 0 in all cases except where funds are lost in the protocol. This value is then used
-        // to offset the exchange rate such that all LPs take on a pro rata loss of funds in a form of the exchangeRate.
         int256 numerator = int256(pooledToken.liquidReserves) +
             pooledToken.utilizedReserves -
             int256(pooledToken.undistributedLpFees);

--- a/contracts/HubPool.sol
+++ b/contracts/HubPool.sol
@@ -430,7 +430,9 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
      * @param haircutAmount The amount of reserves to haircut the LPs by.
      */
     function haircutReserves(address l1Token, int256 haircutAmount) public onlyOwner nonReentrant {
-        pooledTokens[l1Token].haircutReserves = haircutAmount;
+        // Note that we do not call sync first in this method. The Owner should call this manually before haircutting.
+        // This is done in the event sync is reverting due to too low balanced in the contract relative to bond amount.
+        pooledTokens[l1Token].utilizedReserves += haircutAmount;
     }
 
     /*************************************************
@@ -943,8 +945,7 @@ contract HubPool is HubPoolInterface, Testable, Lockable, MultiCaller, Ownable {
         // to offset the exchange rate such that all LPs take on a pro rata loss of funds in a form of the exchangeRate.
         int256 numerator = int256(pooledToken.liquidReserves) +
             pooledToken.utilizedReserves -
-            int256(pooledToken.undistributedLpFees) -
-            pooledToken.haircutReserves;
+            int256(pooledToken.undistributedLpFees);
         return (uint256(numerator) * 1e18) / lpTokenTotalSupply;
     }
 

--- a/contracts/HubPoolInterface.sol
+++ b/contracts/HubPoolInterface.sol
@@ -82,6 +82,8 @@ interface HubPoolInterface {
         // Number of LP funds sent via pool rebalances to SpokePools and are expected to be sent
         // back later.
         int256 utilizedReserves;
+        // In the event an L2 has an irrecoverable loss of funds introduce a haircut that offsets the loss to LPs.
+        int256 haircutReserves;
         // Number of LP funds held in contract less utilized reserves.
         uint256 liquidReserves;
         // Number of LP funds reserved to pay out to LPs as fees.

--- a/contracts/HubPoolInterface.sol
+++ b/contracts/HubPoolInterface.sol
@@ -82,8 +82,6 @@ interface HubPoolInterface {
         // Number of LP funds sent via pool rebalances to SpokePools and are expected to be sent
         // back later.
         int256 utilizedReserves;
-        // In the event an L2 has an irrecoverable loss of funds introduce a haircut that offsets the loss to LPs.
-        int256 haircutReserves;
         // Number of LP funds held in contract less utilized reserves.
         uint256 liquidReserves;
         // Number of LP funds reserved to pay out to LPs as fees.

--- a/test/HubPool.LiquidityProvision.ts
+++ b/test/HubPool.LiquidityProvision.ts
@@ -118,4 +118,14 @@ describe("HubPool Liquidity Provision", function () {
     expect(await usdc.balanceOf(liquidityProvider.address)).to.equal(amountToSeedWallets.sub(scaledAmountToLp.div(2)));
     expect(await usdc.balanceOf(hubPool.address)).to.equal(scaledAmountToLp.div(2));
   });
+  it("Pause disables any liquidity action", async function () {
+    await hubPool.connect(owner).setPaused(true);
+    await weth.connect(liquidityProvider).approve(hubPool.address, amountToLp);
+    await expect(hubPool.connect(liquidityProvider).addLiquidity(weth.address, amountToLp)).to.be.revertedWith(
+      "Contract is paused"
+    );
+    await expect(
+      hubPool.connect(liquidityProvider).removeLiquidity(weth.address, amountToLp, false)
+    ).to.be.revertedWith("Contract is paused");
+  });
 });

--- a/test/HubPool.LiquidityProvisionHaircut.ts
+++ b/test/HubPool.LiquidityProvisionHaircut.ts
@@ -1,0 +1,60 @@
+import { expect, ethers, Contract, SignerWithAddress, seedWallet, toWei } from "./utils";
+import * as consts from "./constants";
+import { hubPoolFixture, enableTokensForLP } from "./fixtures/HubPool.Fixture";
+import { constructSingleChainTree } from "./MerkleLib.utils";
+
+let hubPool: Contract, weth: Contract, timer: Contract;
+let owner: SignerWithAddress, dataWorker: SignerWithAddress, liquidityProvider: SignerWithAddress;
+
+describe("HubPool Liquidity Provision Haircut", function () {
+  beforeEach(async function () {
+    [owner, dataWorker, liquidityProvider] = await ethers.getSigners();
+    ({ weth, hubPool, timer } = await hubPoolFixture());
+    await seedWallet(dataWorker, [], weth, consts.bondAmount.add(consts.finalFee).mul(2));
+    await seedWallet(liquidityProvider, [], weth, consts.amountToLp.mul(10));
+
+    await enableTokensForLP(owner, hubPool, weth, [weth]);
+    await weth.connect(liquidityProvider).approve(hubPool.address, consts.amountToLp);
+    await hubPool.connect(liquidityProvider).addLiquidity(weth.address, consts.amountToLp);
+    await weth.connect(dataWorker).approve(hubPool.address, consts.bondAmount.mul(10));
+  });
+
+  it("Haircut can correctly offset exchange rate current to encapsulate lossed tokens", async function () {
+    const { tokensSendToL2, leaves, tree } = await constructSingleChainTree(weth.address);
+
+    await hubPool
+      .connect(dataWorker)
+      .proposeRootBundle([3117], 1, tree.getHexRoot(), consts.mockTreeRoot, consts.mockSlowRelayRoot);
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + consts.refundProposalLiveness + 1);
+    await hubPool.connect(dataWorker).executeRootBundle(...Object.values(leaves[0]), tree.getHexProof(leaves[0]));
+
+    // Exchange rate current right after the refund execution should be the amount deposited, grown by the 100 second
+    // liveness period. Of the 10 ETH attributed to LPs, a total of 10*0.0000015*7201=0.108015 was attributed to LPs.
+    // The exchange rate is therefore (1000+0.108015)/1000=1.000108015.
+    expect(await hubPool.callStatic.exchangeRateCurrent(weth.address)).to.equal(toWei(1.000108015));
+
+    // At this point if all LP tokens are attempted to be redeemed at the provided exchange rate the call should fail
+    // as the hub pool is currently waiting for funds to come back over the canonical bridge. they are lent out.
+    await expect(hubPool.connect(liquidityProvider).removeLiquidity(weth.address, consts.amountToLp, false)).to.be
+      .reverted;
+
+    // Now, consider that the funds sent over the bridge (tokensSendToL2) are actually lost due to the L2 breaking.
+    // We now need to haircut the LPs be modifying the exchange rate current such that they get a commensurate
+    // redemption rate against the lost funds.
+    await hubPool.haircutReserves(weth.address, tokensSendToL2);
+    await hubPool.sync(weth.address);
+
+    // The exchange rate current should now factor in the loss of funds and should now be less than 1. Taking the amount
+    // attributed to LPs in fees from the previous calculation and the 100 lost tokens, the exchangeRateCurrent should be:
+    // (1000+0.108015-100)/1000=0.900108015.
+    expect(await hubPool.callStatic.exchangeRateCurrent(weth.address)).to.equal(toWei(0.900108015));
+
+    // Now, advance time such that all accumulated rewards are accumulated.
+    await timer.setCurrentTime(Number(await timer.getCurrentTime()) + 10 * 24 * 60 * 60);
+    await hubPool.exchangeRateCurrent(weth.address); // force state sync.
+    expect((await hubPool.pooledTokens(weth.address)).undistributedLpFees).to.equal(0);
+
+    // Exchange rate should now be the (LPAmount + fees - lostTokens) / LPTokenSupply = (1000+10-100)/1000=0.91
+    expect(await hubPool.callStatic.exchangeRateCurrent(weth.address)).to.equal(toWei(0.91));
+  });
+});

--- a/test/HubPool.ProposeRootBundle.ts
+++ b/test/HubPool.ProposeRootBundle.ts
@@ -69,6 +69,6 @@ describe("HubPool Root Bundle Proposal", function () {
     await hubPool.connect(owner).setPaused(true);
     await expect(
       hubPool.proposeRootBundle([1, 2, 3], 5, consts.mockTreeRoot, consts.mockTreeRoot, consts.mockSlowRelayRoot)
-    ).to.be.revertedWith("Proposal process has been paused");
+    ).to.be.revertedWith("Contract is paused");
   });
 });


### PR DESCRIPTION
- Adds untested haircut logic that can scale the exchangeRateCurrent by some haircut amount, in the event of protocol loss of funds.
- Adds the ability to pause the addition/removal of liquidity. should be used in conjunction with haircutting to stop LPs from getting the wrong rate until the hair cut is done.

