### PR TITLE
improve(arbitrum-adapter): Use outboundTransferCustomRefund when sending tokens to L2

### DIFF
--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -29,6 +29,16 @@ interface ArbitrumL1ERC20GatewayLike {
         bytes calldata _data
     ) external payable returns (bytes memory);
 
+    function outboundTransferCustomRefund(
+        address _token,
+        address _refundTo,
+        address _to,
+        uint256 _amount,
+        uint256 _maxGas,
+        uint256 _gasPriceBid,
+        bytes calldata _data
+    ) external payable returns (bytes memory);
+
     function getGateway(address _token) external view returns (address);
 }
 
@@ -59,7 +69,7 @@ contract Arbitrum_Adapter is AdapterInterface {
     uint32 public immutable l2GasLimit = 2_000_000;
 
     // This address on L2 receives extra ETH that is left over after relaying a message via the inbox.
-    address public immutable l2RefundL2Address = 0x428AB2BA90Eba0a4Be7aF34C9Ac451ab061AC010;
+    address public immutable l2RefundL2Address;
 
     ArbitrumL1InboxLike public immutable l1Inbox;
 
@@ -73,6 +83,8 @@ contract Arbitrum_Adapter is AdapterInterface {
     constructor(ArbitrumL1InboxLike _l1ArbitrumInbox, ArbitrumL1ERC20GatewayLike _l1ERC20GatewayRouter) {
         l1Inbox = _l1ArbitrumInbox;
         l1ERC20GatewayRouter = _l1ERC20GatewayRouter;
+
+        l2RefundL2Address = msg.sender;
     }
 
     /**
@@ -132,7 +144,7 @@ contract Arbitrum_Adapter is AdapterInterface {
         // Note: Legacy routers don't have the outboundTransferCustomRefund method, so default to using
         // outboundTransfer(). Legacy routers are used for:
         // - DAI
-        if (l1Token == 0x6b175474e89094c44da98b954eedeac495271d0f) {
+        if (l1Token == 0x6B175474E89094C44Da98b954EedeAC495271d0F) {
             l1ERC20GatewayRouter.outboundTransfer{ value: requiredL1CallValue }(
                 l1Token,
                 to,

--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -137,14 +137,13 @@ contract Arbitrum_Adapter is AdapterInterface {
         // maxSubmissionCost to use when creating an L2 retryable ticket: https://github.com/OffchainLabs/arbitrum/blob/e98d14873dd77513b569771f47b5e05b72402c5e/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol#L232
         bytes memory data = abi.encode(l2MaxSubmissionCost, "");
 
-        // Note: outboundTransfer() will ultimately create a retryable ticket and set this contract's address as the
-        // refund address. This means that the excess ETH to pay for the L2 transaction will be sent to the aliased
-        // contract address on L2 and lost.
-
         // Note: Legacy routers don't have the outboundTransferCustomRefund method, so default to using
         // outboundTransfer(). Legacy routers are used for:
         // - DAI
         if (l1Token == 0x6B175474E89094C44Da98b954EedeAC495271d0F) {
+            // Note: outboundTransfer() will ultimately create a retryable ticket and set this contract's address as the
+            // refund address. This means that the excess ETH to pay for the L2 transaction will be sent to the aliased
+            // contract address on L2 and lost.
             l1ERC20GatewayRouter.outboundTransfer{ value: requiredL1CallValue }(
                 l1Token,
                 to,

--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -138,12 +138,13 @@ contract Arbitrum_Adapter is AdapterInterface {
         bytes memory data = abi.encode(l2MaxSubmissionCost, "");
 
         // Note: Legacy routers don't have the outboundTransferCustomRefund method, so default to using
-        // outboundTransfer(). Legacy routers are used for:
+        // outboundTransfer(). Legacy routers are used for the following tokens that are currently enabled:
         // - DAI
         if (l1Token == 0x6B175474E89094C44Da98b954EedeAC495271d0F) {
             // Note: outboundTransfer() will ultimately create a retryable ticket and set this contract's address as the
             // refund address. This means that the excess ETH to pay for the L2 transaction will be sent to the aliased
-            // contract address on L2 and lost.
+            // contract address on L2, which we'd have to retrieve via a custom adapter
+            // (i.e. the Arbitrum_RescueAdapter).
             l1ERC20GatewayRouter.outboundTransfer{ value: requiredL1CallValue }(
                 l1Token,
                 to,

--- a/contracts/test/ArbitrumMocks.sol
+++ b/contracts/test/ArbitrumMocks.sol
@@ -2,7 +2,8 @@
 pragma solidity ^0.8.0;
 
 contract ArbitrumMockErc20GatewayRouter {
-    function outboundTransfer(
+    function outboundTransferCustomRefund(
+        address,
         address,
         address,
         uint256,

--- a/contracts/test/ArbitrumMocks.sol
+++ b/contracts/test/ArbitrumMocks.sol
@@ -14,6 +14,17 @@ contract ArbitrumMockErc20GatewayRouter {
         return _data;
     }
 
+    function outboundTransfer(
+        address,
+        address,
+        uint256,
+        uint256,
+        uint256,
+        bytes calldata _data
+    ) external payable returns (bytes memory) {
+        return _data;
+    }
+
     function getGateway(address) external view returns (address) {
         return address(this);
     }

--- a/test/chain-adapters/Arbitrum_Adapter.ts
+++ b/test/chain-adapters/Arbitrum_Adapter.ts
@@ -91,14 +91,15 @@ describe("Arbitrum Chain Adapter", function () {
     );
 
     // The correct functions should have been called on the arbitrum contracts.
-    expect(l1ERC20GatewayRouter.outboundTransfer).to.have.been.calledOnce; // One token transfer over the canonical bridge.
+    expect(l1ERC20GatewayRouter.outboundTransferCustomRefund).to.have.been.calledOnce; // One token transfer over the canonical bridge.
 
     // Adapter should have approved gateway to spend its ERC20.
     expect(await dai.allowance(hubPool.address, gatewayAddress)).to.equal(tokensSendToL2);
 
     const message = defaultAbiCoder.encode(["uint256", "bytes"], [consts.sampleL2MaxSubmissionCost, "0x"]);
-    expect(l1ERC20GatewayRouter.outboundTransfer).to.have.been.calledWith(
+    expect(l1ERC20GatewayRouter.outboundTransferCustomRefund).to.have.been.calledWith(
       dai.address,
+      owner.address,
       mockSpoke.address,
       tokensSendToL2,
       consts.sampleL2Gas,


### PR DESCRIPTION
This [merged PR](https://github.com/OffchainLabs/arbitrum/pull/2107) is now live for most Arbitrum ERC20 gateways (except DAI), so we can use the new function outboundTransferCustomRefund to receive refunds at an EOA we control instead of the [aliased hub pool address](https://arbiscan.io/address/0xd297fa914353c44b2e33ebe05f21846f1048cfeb), which is the L1 sender of the tokens technically.