### PR TITLE
chore: remove zksync-web3 from dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,8 +74,7 @@
     "solidity-coverage": "^0.7.16",
     "ts-node": "^10.1.0",
     "typechain": "^5.1.2",
-    "typescript": "^4.5.2",
-    "zksync-web3": "0.7.9"
+    "typescript": "^4.5.2"
   },
   "husky": {
     "hooks": {

--- a/scripts/zkSync.ts
+++ b/scripts/zkSync.ts
@@ -73,10 +73,9 @@ async function main() {
   const currentTime = await spokePool.getCurrentTime();
   console.log(`SpokePool getCurrentTime(): ${currentTime.toString()}`);
   const wethAddress = await spokePool.wrappedNativeToken();
-  console.log(wethAddress, weth.address);
   assert(wethAddress === weth.address, "SpokePool.wrappedNativeToken !== wethAddress");
   const hubPool = await spokePool.hubPool();
-  console.log(`SpokePool hubPool(): ${hubPool.address}`);
+  console.log(`SpokePool hubPool(): ${hubPool}`);
   const enabled = await spokePool.enabledDepositRoutes(erc20.address, config.depositDestinationChainId);
   console.log(`Deposit route to ${config.depositDestinationChainId} enabled? ${enabled}`);
   const rootBundles = await spokePool.rootBundles(config.rootBundleIdToExecute);

--- a/yarn.lock
+++ b/yarn.lock
@@ -14762,11 +14762,6 @@ yocto-queue@^0.1.0:
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
 
-zksync-web3@0.7.9:
-  version "0.7.9"
-  resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.7.9.tgz#fbb9a17f4b297c0fb9361de2a0d85ff2aac5becc"
-  integrity sha512-B0pitKvEQGJuWkY2UWjXrL1YgHghXEoDaq6acVZnB62TRF099GV58Fzi7Fnqt+Nw14A7Wc9iJ2AHD4GBTLFgkg==
-
 zksync-web3@^0.7.8:
   version "0.7.11"
   resolved "https://registry.yarnpkg.com/zksync-web3/-/zksync-web3-0.7.11.tgz#1d829eda9b220b94a3d7e3ab29a2b37ab789a276"


### PR DESCRIPTION
We don't use zksync-web3 since we use the hardhat-deploy plugin's native support for zksync
