### PR TITLE
fix: Fix bug in MerkleDistributor that doesn't decrement remainingAmount for merkle windows correctly

### DIFF
--- a/contracts/merkle-distributor/MerkleDistributor.sol
+++ b/contracts/merkle-distributor/MerkleDistributor.sol
@@ -142,7 +142,6 @@ contract MerkleDistributor is Ownable {
         for (uint256 i = 0; i < claimCount; i++) {
             Claim memory _claim = claims[i];
             _verifyAndMarkClaimed(_claim);
-            merkleWindows[_claim.windowIndex].remainingAmount -= _claim.amount;
             batchedAmount += _claim.amount;
 
             // If the next claim is NOT the same account or the same token (or this claim is the last one),
@@ -172,7 +171,6 @@ contract MerkleDistributor is Ownable {
      */
     function claim(Claim memory _claim) external {
         _verifyAndMarkClaimed(_claim);
-        merkleWindows[_claim.windowIndex].remainingAmount -= _claim.amount;
         merkleWindows[_claim.windowIndex].rewardToken.safeTransfer(_claim.account, _claim.amount);
     }
 
@@ -254,6 +252,7 @@ contract MerkleDistributor is Ownable {
 
         // Proof is correct and claim has not occurred yet, mark claimed complete.
         _setClaimed(_claim.windowIndex, _claim.accountIndex);
+        merkleWindows[_claim.windowIndex].remainingAmount -= _claim.amount;
         emit Claimed(
             msg.sender,
             _claim.windowIndex,

--- a/contracts/merkle-distributor/MerkleDistributor.sol
+++ b/contracts/merkle-distributor/MerkleDistributor.sol
@@ -142,6 +142,7 @@ contract MerkleDistributor is Ownable {
         for (uint256 i = 0; i < claimCount; i++) {
             Claim memory _claim = claims[i];
             _verifyAndMarkClaimed(_claim);
+            merkleWindows[_claim.windowIndex].remainingAmount -= _claim.amount;
             batchedAmount += _claim.amount;
 
             // If the next claim is NOT the same account or the same token (or this claim is the last one),
@@ -156,7 +157,6 @@ contract MerkleDistributor is Ownable {
                 merkleWindows[claims[nextI].windowIndex].rewardToken != currentRewardToken
                 // Next claim reward token is different than current one.
             ) {
-                merkleWindows[_claim.windowIndex].remainingAmount -= batchedAmount;
                 currentRewardToken.safeTransfer(_claim.account, batchedAmount);
                 batchedAmount = 0;
             }

--- a/contracts/merkle-distributor/MerkleDistributor.sol
+++ b/contracts/merkle-distributor/MerkleDistributor.sol
@@ -194,6 +194,15 @@ contract MerkleDistributor is Ownable {
     }
 
     /**
+     * @notice Returns rewardToken set by admin for windowIndex.
+     * @param windowIndex merkle root to check.
+     * @return address Reward token address
+     */
+    function getRewardTokenForWindow(uint256 windowIndex) public view returns (address) {
+        return address(merkleWindows[windowIndex].rewardToken);
+    }
+
+    /**
      * @notice Returns True if leaf described by {account, amount, accountIndex} is stored in Merkle root at given
      *         window index.
      * @param _claim claim object describing amount, accountIndex, account, window index, and merkle proof.

--- a/test/merkle-distributor/MerkleDistributor.ts
+++ b/test/merkle-distributor/MerkleDistributor.ts
@@ -551,11 +551,63 @@ describe("MerkleDistributor", () => {
         const events = await merkleDistributor.queryFilter(eventFilter());
         expect(events.length).to.equal(allRecipients.length * 3);
       });
+      it("Can make multiple claims for one token across multiple windows with single leaf trees", async function () {
+        // This tests that claimMulti correctly decrements `remainingAmount` for each merkle window.
+        const window1RewardAmount = toBN(toWei("100"));
+        const window2RewardAmount = toBN(toWei("300"));
+
+        // Set two windows with trivial one leaf trees.
+        const reward1Recipients = [
+          {
+            account: accounts[3].address,
+            amount: window1RewardAmount.toString(),
+            accountIndex: 1,
+          },
+        ];
+        const reward2Recipients = [
+          {
+            account: accounts[3].address,
+            amount: window2RewardAmount.toString(),
+            accountIndex: 1,
+          },
+        ];
+        const merkleTree1 = new MerkleTree(reward1Recipients.map((item) => createLeaf(item)));
+        const nextWindowIndex = (await merkleDistributor.nextCreatedIndex()).toNumber();
+        await merkleDistributor
+          .connect(contractCreator)
+          .setWindow(window1RewardAmount, rewardToken.address, merkleTree1.getRoot(), "");
+        const merkleTree2 = new MerkleTree(reward2Recipients.map((item) => createLeaf(item)));
+        await merkleDistributor
+          .connect(contractCreator)
+          .setWindow(window2RewardAmount, rewardToken.address, merkleTree2.getRoot(), "");
+
+        batchedClaims = [
+          {
+            windowIndex: nextWindowIndex,
+            account: reward1Recipients[0].account,
+            accountIndex: reward1Recipients[0].accountIndex,
+            amount: reward1Recipients[0].amount,
+            merkleProof: merkleTree1.getProof(createLeaf(reward1Recipients[0])),
+          },
+          {
+            windowIndex: nextWindowIndex + 1,
+            account: reward2Recipients[0].account,
+            accountIndex: reward2Recipients[0].accountIndex,
+            amount: reward2Recipients[0].amount,
+            merkleProof: merkleTree2.getProof(createLeaf(reward2Recipients[0])),
+          },
+        ];
+
+        await merkleDistributor.claimMulti(batchedClaims);
+        // const eventFilter = merkleDistributor.filters.Claimed;
+        // const events = await merkleDistributor.queryFilter(eventFilter());
+        // expect(events.length).to.equal(batchedClaims.length);
+      });
       it("gas", async function () {
         const txn = await merkleDistributor.connect(contractCreator).claimMulti(batchedClaims);
         const receipt = await txn.wait();
         assertApproximate(
-          32860,
+          32185,
           Math.floor(receipt.gasUsed / (rewardLeafs.length * Object.keys(SamplePayouts.recipients).length)),
           0.02
         );


### PR DESCRIPTION
I discovered this by while working on this [PR](https://github.com/across-protocol/across-token/pull/32/files) for the exact test case I've included. The problem arises when all of the claims _for different window indices_ are for the same token and recipient. If this `if` statement [here](https://github.com/across-protocol/contracts-v2/blob/f42e843e351d70692bd8575a44d0f563d1920d8b/contracts/merkle-distributor/MerkleDistributor.sol#L159) is not triggered, then `batchedAmount` accumulates the amount for each claim. It only gets decremented from a window's `remainingAmount` once the if statement is entered, which is either:

- On the last claim
- When the reward token changes between claims
- When the account changes between claims

If the reward token and account do not change, then its possible that `batchedAmount > window.remainingAmount`.

We should be decrementing remainingAmount for each claim that executes, this seems intuitive. 

The reason why I think we've never run into this is because we've never tried claiming in production across multiple windows. I don't think we've even used multiple windows in the past