### PR TITLE
improve: Update speed up signature 

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -698,7 +698,7 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
         // Note: we use encode instead of encodePacked because it is more secure, more in the "warning" section
         // here: https://docs.soliditylang.org/en/v0.8.11/abi-spec.html#non-standard-packed-mode
         bytes32 expectedDepositorMessageHash = keccak256(
-            abi.encode("ACROSS-V2-FEE-1.0", newRelayerFeePct, depositId, originChainId)
+            abi.encode("ACROSS-V2-FEE-2.0", newRelayerFeePct, depositId, originChainId)
         );
 
         // Check the hash corresponding to the https://eth.wiki/json-rpc/API#eth_sign[eth_sign]

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -297,7 +297,7 @@ export async function modifyRelayHelper(
   const messageHash = ethers.utils.keccak256(
     defaultAbiCoder.encode(
       ["string", "uint64", "uint32", "uint32"],
-      ["ACROSS-V2-FEE-1.0", modifiedRelayerFeePct, depositId, originChainId]
+      ["ACROSS-V2-FEE-2.0", modifiedRelayerFeePct, depositId, originChainId]
     )
   );
   const signature = await depositor.signMessage(ethers.utils.arrayify(messageHash));


### PR DESCRIPTION
Upon redeployment of SpokePool may be helpful to avoid signature collisions