### PR TITLE
improve: Default depositQuoteTimeBuffer=3600

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -41,8 +41,8 @@ abstract contract SpokePool is SpokePoolInterface, Testable, Lockable, MultiCall
     WETH9 public immutable wrappedNativeToken;
 
     // Any deposit quote times greater than or less than this value to the current contract time is blocked. Forces
-    // caller to use an approximately "current" realized fee. Defaults to 10 minutes.
-    uint32 public depositQuoteTimeBuffer = 600;
+    // caller to use an approximately "current" realized fee. Defaults to 1 hour.
+    uint32 public depositQuoteTimeBuffer = 3600;
 
     // Count of deposits is used to construct a unique deposit identifier for this spoke pool.
     uint32 public numberOfDeposits;

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -40,7 +40,7 @@ export const repaymentChainId = 777;
 
 export const firstDepositId = 0;
 
-export const depositQuoteTimeBuffer = 10 * 60; // 10 minutes
+export const depositQuoteTimeBuffer = 60 * 60; // 60 minutes
 
 export const bondAmount = toWei("5");
 


### PR DESCRIPTION
This default lines up with what is currently set in the live SpokePools, as depositors realized eventually that making this buffer less strict improved depositor UX and fees didn't change much within the 
hour. This reduces the chance of a deposit reverting if the API providing a suggested fee is stale for an hour.

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
