### PR TITLE
improve: move __gap to bottom of contracts

### DIFF
--- a/contracts/Ovm_SpokePool.sol
+++ b/contracts/Ovm_SpokePool.sol
@@ -27,11 +27,6 @@ contract Ovm_SpokePool is SpokePool {
     // Address of the Optimism L2 messenger.
     address public messenger;
 
-    // Reserve storage slots for future versions of this base contract to add state variables without
-    // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added.
-    uint256[1000] private __gap;
-
     // Stores alternative token bridges to use for L2 tokens that don't go over the standard bridge. This is needed
     // to support non-standard ERC20 tokens on Optimism, such as DIA and SNX which both use custom bridges.
     mapping(address => address) public tokenBridges;
@@ -186,4 +181,9 @@ contract Ovm_SpokePool is SpokePool {
             "OVM_XCHAIN: wrong sender of cross-domain message"
         );
     }
+
+    // Reserve storage slots for future versions of this base contract to add state variables without
+    // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
+    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    uint256[1000] private __gap;
 }

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -62,11 +62,6 @@ abstract contract SpokePool is
     // This contract can store as many root bundles as the HubPool chooses to publish here.
     RootBundle[] public rootBundles;
 
-    // Reserve storage slots for future versions of this base contract to add state variables without
-    // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added.
-    uint256[1000] private __gap;
-
     // Origin token to destination token routings can be turned on or off, which can enable or disable deposits.
     mapping(address => mapping(uint256 => bool)) public enabledDepositRoutes;
 
@@ -942,4 +937,9 @@ abstract contract SpokePool is
 
     // Added to enable the this contract to receive native token (ETH). Used when unwrapping wrappedNativeToken.
     receive() external payable {}
+
+    // Reserve storage slots for future versions of this base contract to add state variables without
+    // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
+    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    uint256[1000] private __gap;
 }

--- a/contracts/upgradeable/EIP712CrossChainUpgradeable.sol
+++ b/contracts/upgradeable/EIP712CrossChainUpgradeable.sol
@@ -24,13 +24,6 @@ abstract contract EIP712CrossChainUpgradeable is Initializable {
     /* solhint-enable var-name-mixedcase */
 
     /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint256[1000] private __gap;
-
-    /**
      * @dev Initializes the domain separator and parameter caches.
      *
      * The meaning of `name` and `version` is specified in
@@ -84,4 +77,9 @@ abstract contract EIP712CrossChainUpgradeable is Initializable {
     function _hashTypedDataV4(bytes32 structHash, uint256 originChainId) internal view virtual returns (bytes32) {
         return ECDSAUpgradeable.toTypedDataHash(_domainSeparatorV4(originChainId), structHash);
     }
+
+    // Reserve storage slots for future versions of this base contract to add state variables without
+    // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
+    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    uint256[1000] private __gap;
 }

--- a/contracts/upgradeable/MultiCallerUpgradeable.sol
+++ b/contracts/upgradeable/MultiCallerUpgradeable.sol
@@ -9,13 +9,6 @@ pragma solidity ^0.8.0;
  * @dev See https://docs.openzeppelin.com/upgrades-plugins/1.x/faq#delegatecall-selfdestruct for more details.
  */
 contract MultiCallerUpgradeable {
-    /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint256[1000] private __gap;
-
     function multicall(bytes[] calldata data) external returns (bytes[] memory results) {
         results = new bytes[](data.length);
         for (uint256 i = 0; i < data.length; i++) {
@@ -39,4 +32,9 @@ contract MultiCallerUpgradeable {
             results[i] = result;
         }
     }
+
+    // Reserve storage slots for future versions of this base contract to add state variables without
+    // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
+    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    uint256[1000] private __gap;
 }

--- a/contracts/upgradeable/TestableUpgradeable.sol
+++ b/contracts/upgradeable/TestableUpgradeable.sol
@@ -14,13 +14,6 @@ abstract contract TestableUpgradeable is Initializable {
     address public timerAddress;
 
     /**
-     * @dev This empty reserved space is put in place to allow future versions to add new
-     * variables without shifting down storage in the inheritance chain.
-     * See https://docs.openzeppelin.com/contracts/4.x/upgradeable#storage_gaps
-     */
-    uint256[1000] private __gap;
-
-    /**
      * @notice Constructs the Testable contract. Called by child contracts.
      * @param _timerAddress Contract that stores the current time in a testing environment.
      * Must be set to 0x0 for production environments that use live time.
@@ -58,4 +51,9 @@ abstract contract TestableUpgradeable is Initializable {
             return block.timestamp; // solhint-disable-line not-rely-on-time
         }
     }
+
+    // Reserve storage slots for future versions of this base contract to add state variables without
+    // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
+    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    uint256[1000] private __gap;
 }


### PR DESCRIPTION
Makes it more obvious that __gap should always be at end of contract storage.

Signed-off-by: nicholaspai <npai.nyc@gmail.com>
