### PR TITLE
improve: [L02] Lack of event emission after sensitive action

### DIFF
--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -35,6 +35,7 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
     event PolygonTokensBridged(address indexed token, address indexed receiver, uint256 amount);
     event SetFxChild(address indexed newFxChild);
     event SetPolygonTokenBridger(address indexed polygonTokenBridger);
+    event ReceivedMessageFromL1(address indexed caller, address indexed rootMessageSender);
 
     // Note: validating calls this way ensures that strange calls coming from the fxChild won't be misinterpreted.
     // Put differently, just checking that msg.sender == fxChild is not sufficient.
@@ -132,6 +133,8 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
         (bool success, ) = address(this).delegatecall(data);
         //slither-disable-end low-level-calls
         require(success, "delegatecall failed");
+
+        emit ReceivedMessageFromL1(msg.sender, rootMessageSender);
     }
 
     /**

--- a/contracts/Succinct_SpokePool.sol
+++ b/contracts/Succinct_SpokePool.sol
@@ -19,6 +19,9 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
     // private. Leaving it set to true can permanently disable admin calls.
     bool private adminCallValidated;
 
+    event SetSuccinctTargetAmb(address indexed newSuccinctTargetAmb);
+    event ReceivedMessageFromL1(address indexed caller, address indexed rootMessageSender);
+
     // Note: validating calls this way ensures that strange calls coming from the succinctTargetAmb won't be misinterpreted.
     // Put differently, just checking that msg.sender == succinctTargetAmb is not sufficient.
     // All calls that have admin privileges must be fired from within the handleTelepathy method that's gone
@@ -68,6 +71,7 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
      */
     function setSuccinctTargetAmb(address _succinctTargetAmb) external onlyAdmin {
         succinctTargetAmb = _succinctTargetAmb;
+        emit SetSuccinctTargetAmb(_succinctTargetAmb);
     }
 
     /**
@@ -91,6 +95,8 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
         /// @custom:oz-upgrades-unsafe-allow delegatecall
         (bool success, ) = address(this).delegatecall(_data);
         require(success, "delegatecall failed");
+
+        emit ReceivedMessageFromL1(msg.sender, _senderAddress);
         return ITelepathyHandler.handleTelepathy.selector;
     }
 


### PR DESCRIPTION
## From Audit:
The `setSuccinctTargetAmb` administrative function does not emit a relevant event after changing the `succinctTargetAmb` address.

Consider always emitting events after sensitive changes take place to facilitate tracking and notify off-chain clients that follow the protocol's contracts' activity.

## Developer response
This PR not only addresses the above issue but adds events to the `Polygon_SpokePool` and `Succinct_SpokePool`'s handler functions that trigger when they are called by an L2 system contract to finalize an L1-->L2 message