### PR TITLE
improve: [L03] Missing docstrings

### DIFF
--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -6,8 +6,20 @@ import "./PolygonTokenBridger.sol";
 import "./interfaces/WETH9Interface.sol";
 import "./SpokePoolInterface.sol";
 
-// IFxMessageProcessor represents interface to process messages.
+/**
+ * @notice IFxMessageProcessor represents interface to process messages.
+ */
 interface IFxMessageProcessor {
+    /**
+     * @notice Called by FxChild upon receiving L1 message that targets this contract. Performs an additional check
+     * that the L1 caller was the expected cross domain admin, and then delegate calls.
+     * @notice Polygon bridge only executes this external function on the target Polygon contract when relaying
+     * messages from L1, so all functions on this SpokePool are expected to originate via this call.
+     * @dev stateId value isn't used because it isn't relevant for this method. It doesn't care what state sync
+     * triggered this call.
+     * @param rootMessageSender Original L1 sender of data.
+     * @param data ABI encoded function call to execute on this contract.
+     */
     function processMessageFromRoot(
         uint256 stateId,
         address rootMessageSender,

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -166,6 +166,21 @@ abstract contract SpokePool is
     event PausedDeposits(bool isPaused);
     event PausedFills(bool isPaused);
 
+    /**
+     * @notice Represents data used to fill a deposit.
+     * @param relay Relay containing original data linked to deposit. Contains fields that can be
+     * overridden by other parametersin the RelayExecution struct.
+     * @param relayHash Hash of the relay data.
+     * @param updatedRelayerFeePct Actual relayer fee pct to use for this relay.
+     * @param updatedRecipient Actual recipient to use for this relay.
+     * @param updatedMessage Actual message to use for this relay.
+     * @param repaymentChainId Chain ID of the network that the relayer will receive refunds on.
+     * @param maxTokensToSend Max number of tokens to pull from relayer.
+     * @param maxCount Max count to protect the relayer from frontrunning.
+     * @param slowFill Whether this is a slow fill.
+     * @param payoutAdjustment Adjustment to the payout amount. Can be used to increase or decrease the payout to allow
+     * for rewards or penalties. Used in slow fills.
+     */
     struct RelayExecution {
         RelayData relay;
         bytes32 relayHash;
@@ -179,20 +194,22 @@ abstract contract SpokePool is
         int256 payoutAdjustmentPct;
     }
 
+    /**
+     * @notice Packs together information to include in FilledRelay event.
+     * @dev This struct is emitted as opposed to its constituent parameters due to the limit on number of
+     * parameters in an event.
+     * @param recipient Recipient of the relayed funds.
+     * @param message Message included in the relay.
+     * @param relayerFeePct Relayer fee pct used for this relay.
+     * @param isSlowRelay Whether this is a slow relay.
+     * @param payoutAdjustmentPct Adjustment to the payout amount.
+     */
     struct RelayExecutionInfo {
         address recipient;
         bytes message;
         int64 relayerFeePct;
         bool isSlowRelay;
         int256 payoutAdjustmentPct;
-    }
-
-    struct DepositUpdate {
-        uint32 depositId;
-        uint256 originChainId;
-        int64 updatedRelayerFeePct;
-        address updatedRecipient;
-        bytes updatedMessage;
     }
 
     /**

--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -36,6 +36,34 @@ interface ArbitrumL1InboxLike {
         uint256 maxFeePerGas,
         bytes calldata data
     ) external payable returns (uint256);
+
+    /**
+     * @notice Put a message in the L2 inbox that can be reexecuted for some fixed amount of time if it reverts
+     * @dev Same as createRetryableTicket, but does not guarantee that submission will succeed by requiring the needed
+     * funds come from the deposit alone, rather than falling back on the user's L2 balance
+     * @dev Advanced usage only (does not rewrite aliases for excessFeeRefundAddress and callValueRefundAddress).
+     * createRetryableTicket method is the recommended standard.
+     * @dev Gas limit and maxFeePerGas should not be set to 1 as that is used to trigger the RetryableData error
+     * @param to destination L2 contract address
+     * @param l2CallValue call value for retryable L2 message
+     * @param maxSubmissionCost Max gas deducted from user's L2 balance to cover base submission fee
+     * @param excessFeeRefundAddress gasLimit x maxFeePerGas - execution cost gets credited here on L2 balance
+     * @param callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled
+     * @param gasLimit Max gas deducted from user's L2 balance to cover L2 execution. Should not be set to 1 (magic value used to trigger the RetryableData error)
+     * @param maxFeePerGas price bid for L2 execution. Should not be set to 1 (magic value used to trigger the RetryableData error)
+     * @param data ABI encoded data of L2 message
+     * @return unique message number of the retryable transaction
+     */
+    function unsafeCreateRetryableTicket(
+        address to,
+        uint256 l2CallValue,
+        uint256 maxSubmissionCost,
+        address excessFeeRefundAddress,
+        address callValueRefundAddress,
+        uint256 gasLimit,
+        uint256 maxFeePerGas,
+        bytes calldata data
+    ) external payable returns (uint256);
 }
 
 /**

--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -6,33 +6,58 @@ import "../interfaces/AdapterInterface.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+/**
+ * @notice Interface for Arbitrum's L1 Inbox contract used to send messages to Arbitrum.
+ */
 interface ArbitrumL1InboxLike {
+    /**
+     * @notice Put a message in the L2 inbox that can be reexecuted for some fixed amount of time if it reverts
+     * @dev Gas limit and maxFeePerGas should not be set to 1 as that is used to trigger the RetryableData error
+     * @dev Caller must set msg.value equal to at least `maxSubmissionCost + maxGas * gasPriceBid`.
+     *      all msg.value will deposited to callValueRefundAddress on L2
+     * @dev More details can be found here: https://developer.arbitrum.io/arbos/l1-to-l2-messaging
+     * @param to destination L2 contract address
+     * @param l2CallValue call value for retryable L2 message
+     * @param maxSubmissionCost Max gas deducted from user's L2 balance to cover base submission fee
+     * @param excessFeeRefundAddress gasLimit x maxFeePerGas - execution cost gets credited here on L2 balance
+     * @param callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled
+     * @param gasLimit Max gas deducted from user's L2 balance to cover L2 execution. Should not be set to 1 (magic value used to trigger the RetryableData error)
+     * @param maxFeePerGas price bid for L2 execution. Should not be set to 1 (magic value used to trigger the RetryableData error)
+     * @param data ABI encoded data of L2 message
+     * @return unique message number of the retryable transaction
+     */
     function createRetryableTicket(
-        address destAddr,
-        uint256 arbTxCallValue,
+        address to,
+        uint256 l2CallValue,
         uint256 maxSubmissionCost,
-        address submissionRefundAddress,
-        address valueRefundAddress,
-        uint256 maxGas,
-        uint256 gasPriceBid,
-        bytes calldata data
-    ) external payable returns (uint256);
-
-    function unsafeCreateRetryableTicket(
-        address destAddr,
-        uint256 arbTxCallValue,
-        uint256 maxSubmissionCost,
-        address submissionRefundAddress,
-        address valueRefundAddress,
-        uint256 maxGas,
-        uint256 gasPriceBid,
+        address excessFeeRefundAddress,
+        address callValueRefundAddress,
+        uint256 gasLimit,
+        uint256 maxFeePerGas,
         bytes calldata data
     ) external payable returns (uint256);
 }
 
+/**
+ * @notice Layer 1 Gateway contract for bridging standard ERC20s to Arbitrum.
+ */
 interface ArbitrumL1ERC20GatewayLike {
+    /**
+     * @notice Deprecated in favor of outboundTransferCustomRefund but still used in custom bridges
+     * like the DAI bridge.
+     * @dev Refunded to aliased L2 address of sender if sender has code on L1, otherwise to to sender's EOA on L2.
+     * @param _l1Token L1 address of ERC20
+     * @param _to Account to be credited with the tokens in the L2 (can be the user's L2 account or a contract),
+     * not subject to L2 aliasing. This account, or its L2 alias if it have code in L1, will also be able to
+     * cancel the retryable ticket and receive callvalue refund
+     * @param _amount Token Amount
+     * @param _maxGas Max gas deducted from user's L2 balance to cover L2 execution
+     * @param _gasPriceBid Gas price for L2 execution
+     * @param _data encoded data from router and user
+     * @return res abi encoded inbox sequence number
+     */
     function outboundTransfer(
-        address _token,
+        address _l1Token,
         address _to,
         uint256 _amount,
         uint256 _maxGas,
@@ -40,8 +65,26 @@ interface ArbitrumL1ERC20GatewayLike {
         bytes calldata _data
     ) external payable returns (bytes memory);
 
+    /**
+     * @notice Deposit ERC20 token from Ethereum into Arbitrum.
+     * @dev L2 address alias will not be applied to the following types of addresses on L1:
+     *      - an externally-owned account
+     *      - a contract in construction
+     *      - an address where a contract will be created
+     *      - an address where a contract lived, but was destroyed
+     * @param _l1Token L1 address of ERC20
+     * @param _refundTo Account, or its L2 alias if it have code in L1, to be credited with excess gas refund in L2
+     * @param _to Account to be credited with the tokens in the L2 (can be the user's L2 account or a contract),
+     * not subject to L2 aliasing. This account, or its L2 alias if it have code in L1, will also be able to
+     * cancel the retryable ticket and receive callvalue refund
+     * @param _amount Token Amount
+     * @param _maxGas Max gas deducted from user's L2 balance to cover L2 execution
+     * @param _gasPriceBid Gas price for L2 execution
+     * @param _data encoded data from router and user
+     * @return res abi encoded inbox sequence number
+     */
     function outboundTransferCustomRefund(
-        address _token,
+        address _l1Token,
         address _refundTo,
         address _to,
         uint256 _amount,
@@ -50,6 +93,11 @@ interface ArbitrumL1ERC20GatewayLike {
         bytes calldata _data
     ) external payable returns (bytes memory);
 
+    /**
+     * @notice get ERC20 gateway for token.
+     * @param _token ERC20 address.
+     * @return address of ERC20 gateway.
+     */
     function getGateway(address _token) external view returns (address);
 }
 

--- a/contracts/chain-adapters/Optimism_Adapter.sol
+++ b/contracts/chain-adapters/Optimism_Adapter.sol
@@ -12,7 +12,15 @@ import "@eth-optimism/contracts/L1/messaging/IL1StandardBridge.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+/**
+ * @notice Interface for Synthetix custom bridge to Optimism.
+ */
 interface SynthetixBridgeToOptimism is IL1StandardBridge {
+    /**
+     * @notice Send tokens to Optimism.
+     * @param to Address to send tokens to on L2.
+     * @param amount Amount of tokens to send.
+     */
     function depositTo(address to, uint256 amount) external;
 }
 

--- a/contracts/chain-adapters/Polygon_Adapter.sol
+++ b/contracts/chain-adapters/Polygon_Adapter.sol
@@ -7,9 +7,22 @@ import "../interfaces/WETH9Interface.sol";
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 
+/**
+ * @notice Send tokens to Polygon.
+ */
 interface IRootChainManager {
+    /**
+     * @notice Send msg.value of ETH to Polygon
+     * @dev Recipient of ETH on Polygon.
+     */
     function depositEtherFor(address user) external payable;
 
+    /**
+     * @notice Send ERC20 tokens to Polygon.
+     * @param user Recipient of L2 equivalent tokens on Polygon.
+     * @param rootToken L1 Address of token to send.
+     * @param depositData Data to pass to L2 including amount of tokens to send. Should be abi.encode(amount).
+     */
     function depositFor(
         address user,
         address rootToken,
@@ -17,11 +30,28 @@ interface IRootChainManager {
     ) external;
 }
 
+/**
+ * @notice Send arbitrary messages to Polygon.
+ */
 interface IFxStateSender {
+    /**
+     * @notice Send arbitrary message to Polygon.
+     * @param _receiver Address on Polygon to receive message.
+     * @param _data Message to send to `_receiver` on Polygon.
+     */
     function sendMessageToChild(address _receiver, bytes calldata _data) external;
 }
 
+/**
+ * @notice Similar to RootChainManager, but for Matic (Plasma) bridge.
+ */
 interface DepositManager {
+    /**
+     * @notice Send tokens to Polygon. Only used to send MATIC in this Polygon_Adapter.
+     * @param token L1 token to send. Should be MATIC.
+     * @param user Recipient of L2 equivalent tokens on Polygon.
+     * @param amount Amount of `token` to send.
+     */
     function depositERC20ForUser(
         address token,
         address user,

--- a/contracts/interfaces/AdapterInterface.sol
+++ b/contracts/interfaces/AdapterInterface.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.0;
 
 /**
  * @notice Sends cross chain messages and tokens to contracts on a specific L2 network.
+ * This interface is implemented by an adapter contract that is deployed on L1.
  */
 
 interface AdapterInterface {
@@ -10,8 +11,26 @@ interface AdapterInterface {
 
     event TokensRelayed(address l1Token, address l2Token, uint256 amount, address to);
 
+    /**
+     * @notice Send message to `target` on L2.
+     * @dev This method is marked payable because relaying the message might require a fee
+     * to be paid by the sender to forward the message to L2. However, it will not send msg.value
+     * to the target contract on L2.
+     * @param target L2 address to send message to.
+     * @param message Message to send to `target`.
+     */
     function relayMessage(address target, bytes calldata message) external payable;
 
+    /**
+     * @notice Send `amount` of `l1Token` to `to` on L2. `l2Token` is the L2 address equivalent of `l1Token`.
+     * @dev This method is marked payable because relaying the message might require a fee
+     * to be paid by the sender to forward the message to L2. However, it will not send msg.value
+     * to the target contract on L2.
+     * @param l1Token L1 token to bridge.
+     * @param l2Token L2 token to receive.
+     * @param amount Amount of `l1Token` to bridge.
+     * @param to Bridge recipient.
+     */
     function relayTokens(
         address l1Token,
         address l2Token,

--- a/contracts/interfaces/LpTokenFactoryInterface.sol
+++ b/contracts/interfaces/LpTokenFactoryInterface.sol
@@ -1,6 +1,15 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity ^0.8.0;
 
+/**
+ * @notice Factory to create new LP ERC20 tokens that represent a liquidity provider's position. HubPool is the
+ * intended client of this contract.
+ */
 interface LpTokenFactoryInterface {
+    /**
+     * @notice Deploys new LP token for L1 token. Sets caller as minter and burner of token.
+     * @param l1Token L1 token to name in LP token name.
+     * @return address of new LP token.
+     */
     function createLpToken(address l1Token) external returns (address);
 }

--- a/contracts/interfaces/WETH9Interface.sol
+++ b/contracts/interfaces/WETH9Interface.sol
@@ -1,12 +1,34 @@
 // SPDX-License-Identifier: GPL-3.0-only
 pragma solidity ^0.8.0;
 
+/**
+ * @notice Interface for the WETH9 contract.
+ */
 interface WETH9Interface {
+    /**
+     * @notice Burn Wrapped Ether and receive native Ether.
+     * @param wad Amount of WETH to unwrap and send to caller.
+     */
     function withdraw(uint256 wad) external;
 
+    /**
+     * @notice Lock native Ether and mint Wrapped Ether ERC20
+     * @dev msg.value is amount of Wrapped Ether to mint/Ether to lock.
+     */
     function deposit() external payable;
 
+    /**
+     * @notice Get balance of WETH held by `guy`.
+     * @param guy Address to get balance of.
+     * @return wad Amount of WETH held by `guy`.
+     */
     function balanceOf(address guy) external view returns (uint256 wad);
 
+    /**
+     * @notice Transfer `wad` of WETH from caller to `guy`.
+     * @param guy Address to send WETH to.
+     * @param wad Amount of WETH to send.
+     * @return ok True if transfer succeeded.
+     */
     function transfer(address guy, uint256 wad) external returns (bool);
 }


### PR DESCRIPTION
## From Audit

Throughout the codebase, there are several parts that do not have docstrings. In particular:

- AdapterInterface.sol , lines 13-20: the interface functions are undocumented.
AbitrumAdapter.sol , lines 9-54: the ArbitrumL1InboxLike and
ArbitrumL1ERC20GatewayLike interfaces and their functions are undocumented.
- LpTokenFactoryInterface.sol , lines 4-5: the interface and its functions are
undocumented.
- Optimism_Adapter.sol , lines 15-16: the SynthetixBridgeToOptimism interface
and its function are undocumented.
- Polygon_Adapter.sol , lines 10-30: the IRootChainManager ,
- IFxStateSender , and DepositManager interfaces and their functions are
undocumented.
- Polygon_SpokePool.sol , line 11: the processMessageFromRoot function is
undocumented.
- SpokePool.sol , lines 169-196: the RelayExecution , RelayExecutionInfo ,
and DepositUpdate structs have undocumented members.
- Succinct_SpokePool.sol , line 57: the initialize function has no docstring.
- Succinct_SpokePool.sol , line 57: the handleTelepathy function has no
docstring.
- WETH9Interface.sol , lines 4-11: the interface and its functions are undocumented.
- ZkSync_Adapter.sol , lines 13-30: the ZkSyncLike and ZkBridgeLike
interfaces and their functions are undocumented.
- ZkSync_SpokePool.sol , lines 6-12: the ZkBridgeLike interface and its function
are undocumented.

Consider thoroughly documenting all functions (and their parameters) that are part of any
contract's public API. Functions implementing sensitive functionality, even if not public, should
be clearly documented as well. When writing docstrings, consider following the Ethereum
Natural Specification Format (NatSpec).

## Developer response

All suggested comments are implemented except for `ZkSync_` contracts which were out of audit scope and are still in progress and not live.
