### PR TITLE
fix: [L04] updatedRelayerFeePct can be lower than expected

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -4,3 +4,5 @@ cache
 coverage*
 gasReporterOutput.json
 typechain
+artifacts-zk
+cache-zk

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
 hardhat.config.ts
 cache
+cache-zk

--- a/.prettierignore
+++ b/.prettierignore
@@ -5,3 +5,5 @@ coverage*
 gasReporterOutput.json
 typechain
 dist
+artifacts-zk
+cache-zk

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -460,7 +460,7 @@ abstract contract SpokePool is
         bytes memory updatedMessage,
         bytes memory depositorSignature
     ) public override nonReentrant {
-        require(updatedRelayerFeePct < 0.5e18, "invalid relayer fee");
+        require(SignedMath.abs(updatedRelayerFeePct) < 0.5e18, "Invalid relayer fee");
 
         _verifyUpdateDepositMessage(
             depositor,

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -303,7 +303,7 @@ async function testUpdatedFeeSignaling(depositorAddress: string) {
     updatedMessage
   );
 
-  // Cannot set new relayer fee pct >= 50%
+  // Cannot set new relayer fee pct >= 50% or <= -50%
   await expect(
     spokePool
       .connect(relayer)
@@ -315,7 +315,19 @@ async function testUpdatedFeeSignaling(depositorAddress: string) {
         updatedMessage,
         signature
       )
-  ).to.be.revertedWith("invalid relayer fee");
+  ).to.be.revertedWith("Invalid relayer fee");
+  await expect(
+    spokePool
+      .connect(relayer)
+      .speedUpDeposit(
+        depositorAddress,
+        toWei("0.5").mul(-1),
+        consts.firstDepositId,
+        updatedRecipient,
+        updatedMessage,
+        signature
+      )
+  ).to.be.revertedWith("Invalid relayer fee");
 
   await expect(
     spokePool


### PR DESCRIPTION
## From Audit

In the SpokePool contract, the speedUpDeposit function performs the following check on
the updatedRelayerFeePct variable:
require(updatedRelayerFeePct < 0.5e18, "invalid relayer fee");
Unlike the equivalent check in the deposit function, in this case the SignedMath.abs
function is not used, which allows the updatedRelayerFeePct value to reach or go below
the lower limit of -0.5e18 . An attempt by the relayer to fill this request will be rejected by the
_fillRelay function's fee check.
Consider using the SignedMath.abs function to ensure the updatedRelayerFeePct
argument provided to speedUpDeposit is within the expected limits.
