### PR TITLE
improve: [N02] Multiple conditions in a single require statement

### DIFF
--- a/contracts/Succinct_SpokePool.sol
+++ b/contracts/Succinct_SpokePool.sol
@@ -83,10 +83,9 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
     ) external override validateInternalCalls returns (bytes4) {
         // Validate msg.sender as succinct, the x-chain sender as being the hubPool (the admin) and the source chain as
         // 1 (mainnet).
-        require(
-            msg.sender == succinctTargetAmb && _senderAddress == hubPool && _sourceChainId == hubChainId,
-            "Invalid message"
-        );
+        require(msg.sender == succinctTargetAmb, "caller not succinct AMB");
+        require(_senderAddress == hubPool, "sender not hubPool");
+        require(_sourceChainId == hubChainId, "source chain not hub chain");
 
         /// @custom:oz-upgrades-unsafe-allow delegatecall
         (bool success, ) = address(this).delegatecall(_data);

--- a/test/chain-specific-spokepools/Succinct_SpokePool.ts
+++ b/test/chain-specific-spokepools/Succinct_SpokePool.ts
@@ -32,16 +32,17 @@ describe("Succinct Spoke Pool", function () {
     // Wrong origin chain id address.
     await expect(
       succinctSpokePool.connect(succinctTargetAmb).handleTelepathy(44, hubPool.address, setCrossDomainAdminData)
-    ).to.be.reverted;
+    ).to.be.revertedWith("source chain not hub chain");
 
     // Wrong rootMessageSender address.
     await expect(
       succinctSpokePool.connect(succinctTargetAmb).handleTelepathy(l1ChainId, rando.address, setCrossDomainAdminData)
-    ).be.reverted;
+    ).be.revertedWith("sender not hubPool");
 
     // Wrong calling address.
-    await expect(succinctSpokePool.connect(rando).handleTelepathy(l1ChainId, hubPool.address, setCrossDomainAdminData))
-      .to.be.reverted;
+    await expect(
+      succinctSpokePool.connect(rando).handleTelepathy(l1ChainId, hubPool.address, setCrossDomainAdminData)
+    ).to.be.revertedWith("caller not succinct AMB");
 
     await succinctSpokePool
       .connect(succinctTargetAmb)


### PR DESCRIPTION
## From Audit

There is a require statement with multiple conditions in the handleTelepathy function of
the Succinct_SpokePool contract.
Consider isolating each condition in its own separate require statement with a corresponding
error message, to more easily identify the specific condition that failed.

## Developer's response

This change allowed me to make unit tests for `Succinct_SpokePool` more strict and check error messages