### PR TITLE
improve: [N04] Typographical errors

### DIFF
--- a/contracts/BondToken.sol
+++ b/contracts/BondToken.sol
@@ -8,7 +8,7 @@ import "./HubPoolInterface.sol";
 import "./external/WETH9.sol";
 
 interface ExtendedHubPoolInterface is HubPoolInterface {
-    // Specify the automatically-implemented rootBundleProposer() getter.
+    // Specify the automatically-implemented rootBundleProposal() getter.
     function rootBundleProposal() external pure returns (HubPoolInterface.RootBundle memory);
 }
 
@@ -18,7 +18,7 @@ interface ExtendedHubPoolInterface is HubPoolInterface {
  * imposes address-based permissioning on the WETH9 transferFrom() function in order to constrain the movement of ABT
  * into the Across v2 HubPool contract. When configured as the required HubPool bond token, ABT can dramatically reduce
  * the attack surface of the HubPool by requiring that addresses are explicitly approved before they can successfully
- * submit a root bundle proposal. The address-based permissiong does not constrain transfers that are needed to dispute
+ * submit a root bundle proposal. The address-based permissioning does not constrain transfers that are needed to dispute
  * a root bundle proposal, so the ability of decentralised/unknown actors to dispute is unaffected.
  */
 contract BondToken is WETH9, Ownable {

--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -48,7 +48,7 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
 
         // This sets a variable indicating that we're now inside a validated call.
         // Note: this is used by other methods to ensure that this call has been validated by this method and is not
-        // spoofed. See
+        // spoofed. See comment for `_requireAdminSender` for more details.
         callValidated = true;
 
         _;
@@ -136,8 +136,9 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
 
     /**
      * @notice Allows the caller to trigger the wrapping of any unwrapped matic tokens.
-     * @dev Matic sends via L1 -> L2 bridging actions don't call into the contract receiving the tokens, so wrapping
-     * must be done via a separate transaction.
+     * @dev Unlike other ERC20 transfers, Matic transfers from L1 -> L2 bridging don't result in an L2 call into
+     * the contract receiving the tokens, so wrapping must be done via a separate transaction. In other words,
+     * we can't rely upon a `fallback()` method being triggered to wrap MATIC upon receiving it.
      */
     function wrap() public nonReentrant {
         _wrap();

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -564,7 +564,7 @@ abstract contract SpokePool is
     /**
      * @notice Called by relayer to execute same logic as calling fillRelay except that relayer is using an updated
      * relayer fee %. The fee % must have been emitted in a message cryptographically signed by the depositor.
-     * @notice By design, the depositor probably emitted the message with the updated fee by calling speedUpRelay().
+     * @notice By design, the depositor probably emitted the message with the updated fee by calling speedUpDeposit().
      * @param depositor Depositor on origin chain who set this chain as the destination chain.
      * @param recipient Specified recipient on this chain.
      * @param destinationToken Token to send to recipient. Should be mapped to the origin token, origin chain ID
@@ -1168,6 +1168,6 @@ abstract contract SpokePool is
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    // are added. This is at bottom of contract to make sure it's always at the end of storage.
     uint256[1000] private __gap;
 }

--- a/contracts/Succinct_SpokePool.sol
+++ b/contracts/Succinct_SpokePool.sol
@@ -19,13 +19,13 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
     // private. Leaving it set to true can permanently disable admin calls.
     bool private adminCallValidated;
 
-    // Note: validating calls this way ensures that strange calls coming from the succinctTargetAmb won't be misinterpreted.
-    // Put differently, just checking that msg.sender == succinctTargetAmb is not sufficient.
+    // Note: validating calls this way ensures that strange calls coming from the succinctTargetAmb won't be
+    // misinterpreted. Put differently, just checking that msg.sender == succinctTargetAmb is not sufficient.
     // All calls that have admin privileges must be fired from within the handleTelepathy method that's gone
     // through validation where the sender is checked and the sender from the other chain is also validated.
-    // This modifier sets the callValidated variable so this condition can be checked in _requireAdminSender().
+    // This modifier sets the adminCallValidated variable so this condition can be checked in _requireAdminSender().
     modifier validateInternalCalls() {
-        // Make sure callValidated is set to True only once at beginning of processMessageFromRoot, which prevents
+        // Make sure adminCallValidated is set to True only once at beginning of processMessageFromRoot, which prevents
         // processMessageFromRoot from being re-entered.
         require(!adminCallValidated, "adminCallValidated already set");
 
@@ -36,7 +36,7 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
 
         _;
 
-        // Reset callValidated to false to disallow admin calls after this method exits.
+        // Reset adminCallValidated to false to disallow admin calls after this method exits.
         adminCallValidated = false;
     }
 

--- a/contracts/chain-adapters/Optimism_Adapter.sol
+++ b/contracts/chain-adapters/Optimism_Adapter.sol
@@ -20,7 +20,7 @@ interface SynthetixBridgeToOptimism is IL1StandardBridge {
  * @notice Contract containing logic to send messages from L1 to Optimism.
  * @dev Public functions calling external contracts do not guard against reentrancy because they are expected to be
  * called via delegatecall, which will execute this contract's logic within the context of the originating contract.
- * For example, the HubPool will delegatecall these functions, therefore its only necessary that the HubPool's methods
+ * For example, the HubPool will delegatecall these functions, therefore it's only necessary that the HubPool's methods
  * that call this contract's logic guard against reentrancy.
  */
 

--- a/contracts/chain-adapters/Succinct_Adapter.sol
+++ b/contracts/chain-adapters/Succinct_Adapter.sol
@@ -24,7 +24,7 @@ contract Succinct_Adapter is AdapterInterface {
 
     /**
      * @notice Send cross-chain message to target on the destination.
-     * @param target Contract on the destinatipn that will receive the message..
+     * @param target Contract on the destination that will receive the message.
      * @param message Data to send to target.
      */
     function relayMessage(address target, bytes calldata message) external payable override {

--- a/contracts/upgradeable/EIP712CrossChainUpgradeable.sol
+++ b/contracts/upgradeable/EIP712CrossChainUpgradeable.sol
@@ -80,6 +80,6 @@ abstract contract EIP712CrossChainUpgradeable is Initializable {
 
     // Reserve storage slots for future versions of this base contract to add state variables without
     // affecting the storage layout of child contracts. Decrement the size of __gap whenever state variables
-    // are added. This is at bottom of contract to make sure its always at the end of storage.
+    // are added. This is at bottom of contract to make sure it's always at the end of storage.
     uint256[1000] private __gap;
 }

--- a/contracts/upgradeable/MultiCallerUpgradeable.sol
+++ b/contracts/upgradeable/MultiCallerUpgradeable.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 /**
- * @title MockSpokePool
+ * @title MultiCallerUpgradeable
  * @notice Logic is 100% copied from "@uma/core/contracts/common/implementation/MultiCaller.sol" but one
  * comment is added to clarify why we allow delegatecall() in this contract, which is typically unsafe for use in
  * upgradeable implementation contracts.


### PR DESCRIPTION
## From Audit

Consider correcting the following typographical errors:
In BondToken.sol :
Line 11, "rootBundleProposer()" should be "rootBundleProposal()".
Line 21: "permissiong" should be "permissioning".
In EIP712CrossChainUpgradeable.sol :
Line 83: "its always" should be "it's always".
In MultiCallerUpgradeable.sol :
Line 5: "@title MockSpokePool" should be "@title MultiCallerUpgradeable".
In Optimism_Adapter.sol :
Line 23: "its only" should be "it's only".
In Polygon_SpokePool.sol :
Line 51: the sentence "See" is incomplete.
Line 139: the sentence is malformed.
In SpokePool.sol :
Line 567: "speedUpRelay()" should be "speedUpDeposit()".
Line 1177: "its always" should be "it's always".
In Succinct_Adapter.sol :
Line 27: "destinatipn" should be "destination".
Line 27: "the message.." should be "the message.".
In Succinct_SpokePool.sol :
Line 22: "callValidated" should be "adminCallValidated".
Line 24: "callValidated" should be "adminCallValidated".
Line 35: "callValidated" should be "adminCallValidated".
