### PR TITLE
improve: [N05] Unecessary modulo operation

### DIFF
--- a/contracts/MerkleLib.sol
+++ b/contracts/MerkleLib.sol
@@ -102,6 +102,6 @@ library MerkleLib {
      * @return uint256 representing the modified input claimedBitMap with the index set to true.
      */
     function setClaimed1D(uint256 claimedBitMap, uint8 index) internal pure returns (uint256) {
-        return claimedBitMap | (1 << index % 256);
+        return claimedBitMap | (1 << index);
     }
 }


### PR DESCRIPTION
## From Audit

The setClaimed1D function in MerkleLib.sol performs a modulo 256 operation on
index to yield a result in the range [0, 255]. However, index is a uint8 variable, so the
operation index % 256 is equivalent to index .
Consider removing the redundant modulo operation.