### PR TITLE
improve: [N07] Use of hard-coded values

### DIFF
--- a/contracts/Ovm_SpokePool.sol
+++ b/contracts/Ovm_SpokePool.sol
@@ -27,6 +27,12 @@ contract Ovm_SpokePool is SpokePool {
     // Address of the Optimism L2 messenger.
     address public messenger;
 
+    // Address of custom bridge used to bridge Synthetix-related assets like SNX.
+    address private constant SYNTHETIX_BRIDGE = 0x136b1EC699c62b0606854056f02dC7Bb80482d63;
+
+    // Address of SNX ERC20
+    address private constant SNX = 0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4;
+
     // Stores alternative token bridges to use for L2 tokens that don't go over the standard bridge. This is needed
     // to support non-standard ERC20 tokens on Optimism, such as DIA and SNX which both use custom bridges.
     mapping(address => address) public tokenBridges;
@@ -157,8 +163,8 @@ contract Ovm_SpokePool is SpokePool {
             relayerRefundLeaf.l2TokenAddress = l2Eth; // Set the l2TokenAddress to ETH.
         }
         // Handle custom SNX bridge which doesn't conform to the standard bridge interface.
-        if (relayerRefundLeaf.l2TokenAddress == 0x8700dAec35aF8Ff88c16BdF0418774CB3D7599B4)
-            SynthetixBridgeToBase(0x136b1EC699c62b0606854056f02dC7Bb80482d63).withdrawTo(
+        if (relayerRefundLeaf.l2TokenAddress == SNX)
+            SynthetixBridgeToBase(SYNTHETIX_BRIDGE).withdrawTo(
                 hubPool, // _to. Withdraw, over the bridge, to the l1 pool contract.
                 relayerRefundLeaf.amountToReturn // _amount.
             );


### PR DESCRIPTION
## From Audit

The _bridgeTokensToHubPool function in the Ovm_SpokePool contract contains two
hard-coded addresses that are not explicitly documented.
Consider creating constants to store these values, and assigning them descriptive variable
names.
