### PR TITLE
fix: fix potential underpayment in slow fill with negative LP fees

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -89,6 +89,12 @@ abstract contract SpokePool is
 
     uint256 public constant MAX_TRANSFER_SIZE = 1e36;
 
+    // Note: this needs to be larger than the max transfer size to ensure that all slow fills are fillable, even if
+    // their fees are negative.
+    // It's important that it isn't too large, however, as it should be multipliable by ~2e18 without overflowing.
+    // 1e40 * 2e18 = 2e58 << 2^255 ~= 5e76
+    uint256 public constant SLOW_FILL_MAX_TOKENS_TO_SEND = 1e40;
+
     bytes32 public constant UPDATE_DEPOSIT_DETAILS_HASH =
         keccak256(
             "UpdateDepositDetails(uint32 depositId,uint256 originChainId,int64 updatedRelayerFeePct,address updatedRecipient,bytes updatedMessage)"
@@ -867,7 +873,7 @@ abstract contract SpokePool is
             updatedRecipient: recipient,
             updatedMessage: message,
             repaymentChainId: 0,
-            maxTokensToSend: amount,
+            maxTokensToSend: SLOW_FILL_MAX_TOKENS_TO_SEND,
             slowFill: true,
             payoutAdjustmentPct: payoutAdjustmentPct,
             maxCount: type(uint256).max
@@ -1049,16 +1055,18 @@ abstract contract SpokePool is
                 fillAmountPreFees,
                 relayData.realizedLpFeePct + relayExecution.updatedRelayerFeePct
             );
+        }
 
-            if (relayExecution.payoutAdjustmentPct != 0) {
-                // If payoutAdjustmentPct is positive, then the recipient will receive more than the amount they
-                // were originally expecting. If it is negative, then the recipient will receive less.
-                // -1e18 is -100%. Because we cannot pay out negative values, that is the minimum.
-                require(relayExecution.payoutAdjustmentPct >= -1e18, "payoutAdjustmentPct too small");
+        // This can only happen in a slow fill, where the contract is funding the relay, so the maxTokensToSend can be ignored.
+        // This is why we don't check that the amountToSend is less than or equal to maxTokensToSend.
+        if (relayExecution.payoutAdjustmentPct != 0) {
+            // If payoutAdjustmentPct is positive, then the recipient will receive more than the amount they
+            // were originally expecting. If it is negative, then the recipient will receive less.
+            // -1e18 is -100%. Because we cannot pay out negative values, that is the minimum.
+            require(relayExecution.payoutAdjustmentPct >= -1e18, "payoutAdjustmentPct too small");
 
-                // Note: since _computeAmountPostFees is typicaly intended for fees, the signage must be reversed.
-                amountToSend = _computeAmountPostFees(amountToSend, -relayExecution.payoutAdjustmentPct);
-            }
+            // Note: since _computeAmountPostFees is typicaly intended for fees, the signage must be reversed.
+            amountToSend = _computeAmountPostFees(amountToSend, -relayExecution.payoutAdjustmentPct);
         }
 
         // Update fill counter.

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1076,7 +1076,7 @@ abstract contract SpokePool is
 
             // Note: this error should never happen, since the maxTokensToSend is expected to be set much higher than
             // the amount, but it is here as a sanity check.
-            require(amountToSend <= relayExecution.maxTokensToSend, "payoutAdjustmentPct too large");
+            require(amountToSend <= relayExecution.maxTokensToSend, "Somehow hit maxTokensToSend!");
         }
 
         // Update fill counter.

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -47,8 +47,8 @@ describe("SpokePool Slow Relay Logic", async function () {
     await seedWallet(relayer, [destErc20], weth, consts.amountToSeedWallets);
 
     // Send tokens to the spoke pool for repayment.
-    await destErc20.connect(depositor).transfer(spokePool.address, fullRelayAmountPostFees);
-    await weth.connect(depositor).transfer(spokePool.address, fullRelayAmountPostFees);
+    await destErc20.connect(depositor).transfer(spokePool.address, fullRelayAmountPostFees.mul(10));
+    await weth.connect(depositor).transfer(spokePool.address, fullRelayAmountPostFees.div(2));
 
     // Approve spoke pool to take relayer's tokens.
     await destErc20.connect(relayer).approve(spokePool.address, fullRelayAmountPostFees);
@@ -91,7 +91,7 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositId: consts.firstDepositId.toString(),
         message: erc20Message,
       },
-      payoutAdjustmentPct: "0",
+      payoutAdjustmentPct: ethers.utils.parseEther("9"), // 10x payout.
     });
 
     // WETH
@@ -108,7 +108,7 @@ describe("SpokePool Slow Relay Logic", async function () {
         depositId: consts.firstDepositId.toString(),
         message: wethMessage,
       },
-      payoutAdjustmentPct: "0",
+      payoutAdjustmentPct: ethers.utils.parseEther("-0.5"), // 50% payout.
     });
 
     tree = await buildSlowRelayTree(slowFills);
@@ -131,14 +131,14 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.firstDepositId,
             0,
             erc20Message,
-            ZERO,
+            ethers.utils.parseEther("9"),
             tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === destErc20.address)!)
           )
         )
     ).to.changeTokenBalances(
       destErc20,
       [spokePool, recipient],
-      [fullRelayAmountPostFees.mul(-1), fullRelayAmountPostFees]
+      [fullRelayAmountPostFees.mul(10).mul(-1), fullRelayAmountPostFees.mul(10)]
     );
   });
 
@@ -160,7 +160,7 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.firstDepositId,
             0,
             erc20Message,
-            ZERO,
+            ethers.utils.parseEther("9"),
             tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === destErc20.address)!)
           )
         )
@@ -206,11 +206,11 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.firstDepositId,
             0,
             wethMessage,
-            ZERO,
+            ethers.utils.parseEther("-0.5"),
             tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === weth.address)!)
           )
         )
-    ).to.changeTokenBalances(weth, [spokePool], [fullRelayAmountPostFees.mul(-1)]);
+    ).to.changeTokenBalances(weth, [spokePool], [fullRelayAmountPostFees.div(2).mul(-1)]);
   });
 
   it("Simple SlowRelay ETH balance", async function () {
@@ -229,11 +229,11 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.firstDepositId,
             0,
             wethMessage,
-            ZERO,
+            ethers.utils.parseEther("-0.5"),
             tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === weth.address)!)
           )
         )
-    ).to.changeEtherBalance(recipient, fullRelayAmountPostFees);
+    ).to.changeEtherBalance(recipient, fullRelayAmountPostFees.div(2));
   });
 
   it("Partial SlowRelay ERC20 balances", async function () {
@@ -278,11 +278,15 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.firstDepositId,
             0,
             erc20Message,
-            ZERO,
+            ethers.utils.parseEther("9"),
             tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === destErc20.address)!)
           )
         )
-    ).to.changeTokenBalances(destErc20, [spokePool, recipient], [leftoverPostFees.mul(-1), leftoverPostFees]);
+    ).to.changeTokenBalances(
+      destErc20,
+      [spokePool, recipient],
+      [leftoverPostFees.mul(10).mul(-1), leftoverPostFees.mul(10)]
+    );
   });
 
   it("Partial SlowRelay WETH balance", async function () {
@@ -326,11 +330,11 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.firstDepositId,
             0,
             wethMessage,
-            ZERO,
+            ethers.utils.parseEther("-0.5"),
             tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === weth.address)!)
           )
         )
-    ).to.changeTokenBalances(weth, [spokePool], [leftoverPostFees.mul(-1)]);
+    ).to.changeTokenBalances(weth, [spokePool], [leftoverPostFees.div(2).mul(-1)]);
   });
 
   it("Partial SlowRelay ETH balance", async function () {
@@ -374,11 +378,11 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.firstDepositId,
             0,
             wethMessage,
-            ZERO,
+            ethers.utils.parseEther("-0.5"),
             tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === weth.address)!)
           )
         )
-    ).to.changeEtherBalance(recipient, leftoverPostFees);
+    ).to.changeEtherBalance(recipient, leftoverPostFees.div(2));
   });
 
   it("Bad proof: Relay data is correct except that destination chain ID doesn't match spoke pool's", async function () {


### PR DESCRIPTION
There was one major issue and a related minor issue discovered around how payoutAdjustmentPct was handled:
1.  In the case where there is a slow fill on a deposit with a negative LP fee, the maxSendAmount passed into the _fillRelay function could cause fillAmountPreFees to be less than the amount, which means it could be less than amountRemainingInRelay. In this case, two errors would occur: a) the slow fill would not complete the fill and b) the payoutAdjustmentPct would be ignored because it is inside the if statement comparing fillAmountPreFees to amountRemainingInRelay.
2. The payoutAdjustmentPct could be set arbitrarily high, potentially causing math overflows. Note: I don't think this would cause any mathematical _errors_ but it could certainly trigger cryptic overflows.

To fix this:
1. The maxSendAmount in the slow fill method was set to a number that is much 1e4 times larger than the max transfer size. Because the minimum LP fee is -50%, this should be more than sufficient to ensure that it is larger than any possible transfer.
2. The payoutAdjustmentPct logic was moved out from the if statement that it was previously inside.
3. A check was added to ensure that the final payout was still smaller than the maxSendAmount when payoutAdjustmentPct != 0.
4. The payoutAdjustmentPct was limited to being 1e2 or smaller. This means it can never cause overflows.