### PR TITLE
improve(docstrings): Follow up fixes

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -191,7 +191,7 @@ abstract contract SpokePool is
     /**
      * @notice Represents data used to fill a deposit.
      * @param relay Relay containing original data linked to deposit. Contains fields that can be
-     * overridden by other parametersin the RelayExecution struct.
+     * overridden by other parameters in the RelayExecution struct.
      * @param relayHash Hash of the relay data.
      * @param updatedRelayerFeePct Actual relayer fee pct to use for this relay.
      * @param updatedRecipient Actual recipient to use for this relay.
@@ -200,8 +200,8 @@ abstract contract SpokePool is
      * @param maxTokensToSend Max number of tokens to pull from relayer.
      * @param maxCount Max count to protect the relayer from frontrunning.
      * @param slowFill Whether this is a slow fill.
-     * @param payoutAdjustment Adjustment to the payout amount. Can be used to increase or decrease the payout to allow
-     * for rewards or penalties. Used in slow fills.
+     * @param payoutAdjustmentPct Adjustment to the payout amount. Can be used to increase or decrease the payout to
+     * allow for rewards or penalties. Used in slow fills.
      */
     struct RelayExecution {
         RelayData relay;

--- a/contracts/chain-adapters/Polygon_Adapter.sol
+++ b/contracts/chain-adapters/Polygon_Adapter.sol
@@ -13,7 +13,7 @@ import "@openzeppelin/contracts/token/ERC20/utils/SafeERC20.sol";
 interface IRootChainManager {
     /**
      * @notice Send msg.value of ETH to Polygon
-     * @dev Recipient of ETH on Polygon.
+     * @param user Recipient of ETH on Polygon.
      */
     function depositEtherFor(address user) external payable;
 


### PR DESCRIPTION
- In Polygon_Adapter.sol, the user parameter for the depositEtherFor function is documented using "@dev" instead of "@param user".
- In SpokePool.sol, within the RelayExecution struct's relay parameter description, "parametersin" should be "parameters in".
- In SpokePool.sol, the RelayExecution struct's docstring for parameter payoutAdjustmentPct lists it as "payoutAdjustment".