### PR TITLE
build: workaround @uma/common package browser compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.1.0-beta.3",
+  "version": "2.1.0-beta.4",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/utils/MerkleTree.ts
+++ b/utils/MerkleTree.ts
@@ -1,1 +1,4 @@
-export { MerkleTree, EMPTY_MERKLE_ROOT } from "@uma/common";
+// The package `@uma/common` can not be tree-shaken and contains some modules that are not
+// compatible with the browser. This is a temporary fix to avoid bundling the whole package
+// until we can fix the issue upstream.
+export { MerkleTree, EMPTY_MERKLE_ROOT } from "@uma/common/dist/MerkleTree";


### PR DESCRIPTION
I encountered this error in the frontend again when updating to the beta SDK version
```
./node_modules/@across-protocol/contracts-v2/node_modules/@uma/common/dist/HardhatConfig.js
Cannot find module: 'hardhat-tracer'. Make sure this package is installed.

You can install this package by running: yarn add hardhat-tracer.
```

This PR provides a temporary fix until the issue is fixed upstream.