### PR TITLE
fix: Prevent partial fills with messages

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1193,6 +1193,13 @@ abstract contract SpokePool is
             "invalid repayment chain"
         );
 
+        // If this is a partial fill, require that the fill has no message. This prevents situations in which
+        // a message is sent multiple times for multiple partial fills.
+        require(
+            relayExecution.relay.amount == fillAmountPreFees || relayExecution.updatedMessage.length == 0,
+            "invalid partial fill message"
+        );
+
         // Update fill counter.
         _updateCountFromFill(
             relayFills[relayExecution.relayHash],

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -305,18 +305,24 @@ describe("SpokePool Relayer Logic", async function () {
       "0x1234"
     );
 
+    // Partial fills fail with a message:
+    await expect(
+      spokePool
+        .connect(relayer)
+        .fillRelay(...getFillRelayParams(relayData, consts.amountToRelay, consts.destinationChainId))
+    ).to.be.revertedWith("invalid partial fill message");
     await spokePool
       .connect(relayer)
-      .fillRelay(...getFillRelayParams(relayData, consts.amountToRelay, consts.destinationChainId));
+      .fillRelay(...getFillRelayParams(relayData, relayData.amount, consts.destinationChainId));
 
     expect(acrossMessageHandler.handleAcrossMessage).to.have.been.calledOnceWith(
       weth.address,
-      consts.amountToRelay,
+      consts.amountToDepositPostFees,
       "0x1234"
     );
 
     // The collateral should have not unwrapped to ETH and then transferred to recipient.
-    expect(await weth.balanceOf(acrossMessageHandler.address)).to.equal(consts.amountToRelay);
+    expect(await weth.balanceOf(acrossMessageHandler.address)).to.equal(consts.amountToDepositPostFees);
   });
   it("Self-relay transfers no tokens", async function () {
     const largeRelayAmount = consts.amountToSeedWallets.mul(100);
@@ -616,7 +622,7 @@ async function testfillRelayWithUpdatedDeposit(depositorAddress: string) {
       .fillRelayWithUpdatedDeposit(
         ...getFillRelayUpdatedFeeParams(
           relayData,
-          consts.amountToRelay,
+          relayData.amount,
           consts.modifiedRelayerFeePct,
           signature,
           consts.destinationChainId,
@@ -628,8 +634,8 @@ async function testfillRelayWithUpdatedDeposit(depositorAddress: string) {
     .to.emit(spokePool, "FilledRelay")
     .withArgs(
       relayData.amount,
-      consts.amountToRelayPreModifiedFees,
-      consts.amountToRelayPreModifiedFees,
+      relayData.amount,
+      relayData.amount,
       consts.destinationChainId,
       toBN(relayData.originChainId),
       toBN(relayData.destinationChainId),
@@ -659,19 +665,19 @@ async function testfillRelayWithUpdatedDeposit(depositorAddress: string) {
 
   // The collateral should have transferred from relayer to recipient.
   const relayerBalance = await destErc20.balanceOf(relayer.address);
-  const expectedRelayerBalance = consts.amountToSeedWallets.sub(consts.amountToRelay);
+  const expectedRelayerBalance = consts.amountToSeedWallets.sub(consts.amountToDepositPostFees);
 
   // Note: We need to add an error bound of 1 wei to the expected balance because of the possibility
   // of rounding errors with the modified fees. The unmodified fees result in clean numbers but the modified fee does not.
   expect(relayerBalance.gte(expectedRelayerBalance.sub(1)) || relayerBalance.lte(expectedRelayerBalance.add(1))).to.be
     .true;
   const recipientBalance = amountActuallySent;
-  const expectedRecipientBalance = consts.amountToRelay;
+  const expectedRecipientBalance = consts.amountToDepositPostFees;
   expect(recipientBalance.gte(expectedRecipientBalance.sub(1)) || recipientBalance.lte(expectedRecipientBalance.add(1)))
     .to.be.true;
 
   // Fill amount should be be set taking into account modified fees.
-  expect(await spokePool.relayFills(relayHash)).to.equal(consts.amountToRelayPreModifiedFees);
+  expect(await spokePool.relayFills(relayHash)).to.equal(relayData.amount);
 }
 
 async function testUpdatedFeeSignatureFailCases(depositorAddress: string) {

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -79,6 +79,18 @@ describe("SpokePool Slow Relay Logic", async function () {
     }
 
     // ERC20
+    const erc20LeafRelayData = {
+      depositor: depositor.address,
+      recipient: recipient.address,
+      destinationToken: destErc20.address,
+      amount: consts.amountToRelay,
+      originChainId: consts.originChainId.toString(),
+      destinationChainId: consts.destinationChainId.toString(),
+      realizedLpFeePct: consts.realizedLpFeePct,
+      relayerFeePct: consts.depositRelayerFeePct,
+      depositId: consts.firstDepositId.toString(),
+      message: erc20Message,
+    };
     slowFills.push({
       relayData: {
         depositor: depositor.address,
@@ -96,6 +108,18 @@ describe("SpokePool Slow Relay Logic", async function () {
     });
 
     // WETH
+    const wethLeafRelayData = {
+      depositor: depositor.address,
+      recipient: recipient.address,
+      destinationToken: weth.address,
+      amount: consts.amountToRelay,
+      originChainId: consts.originChainId.toString(),
+      destinationChainId: consts.destinationChainId.toString(),
+      realizedLpFeePct: consts.realizedLpFeePct,
+      relayerFeePct: consts.depositRelayerFeePct,
+      depositId: consts.firstDepositId.toString(),
+      message: wethMessage,
+    };
     slowFills.push({
       relayData: {
         depositor: depositor.address,
@@ -296,7 +320,7 @@ describe("SpokePool Slow Relay Logic", async function () {
           consts.amountToRelay,
           undefined,
           undefined,
-          erc20Message
+          "0x"
         ).relayData,
         partialAmountPostFees, // Set post fee amount as max amount to send so that relay filled amount is
         // decremented by exactly the `partialAmount`.
@@ -317,9 +341,14 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.depositRelayerFeePct,
             consts.firstDepositId,
             0,
-            erc20Message,
+            "0x",
             ethers.utils.parseEther("9"),
-            tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === destErc20.address)!)
+            tree.getHexProof(
+              slowFills.find(
+                (slowFill) =>
+                  slowFill.relayData.destinationToken === destErc20.address && slowFill.relayData.message === "0x"
+              )!
+            )
           )
         )
     ).to.changeTokenBalances(
@@ -353,7 +382,7 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.amountToRelay,
             undefined,
             undefined,
-            wethMessage
+            "0x"
           ).relayData,
           partialAmountPostFees,
           consts.destinationChainId
@@ -374,9 +403,14 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.depositRelayerFeePct,
             consts.firstDepositId,
             0,
-            wethMessage,
+            "0x",
             ethers.utils.parseEther("-0.5"),
-            tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === weth.address)!)
+            tree.getHexProof(
+              slowFills.find(
+                (slowFill) =>
+                  slowFill.relayData.destinationToken === weth.address && slowFill.relayData.message === "0x"
+              )!
+            )
           )
         )
     ).to.changeTokenBalances(weth, [spokePool], [slowFillAmountPostFees.div(2).mul(-1)]);
@@ -406,7 +440,7 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.amountToRelay,
             undefined,
             undefined,
-            wethMessage
+            "0x"
           ).relayData,
           partialAmountPostFees,
           consts.destinationChainId
@@ -427,9 +461,14 @@ describe("SpokePool Slow Relay Logic", async function () {
             consts.depositRelayerFeePct,
             consts.firstDepositId,
             0,
-            wethMessage,
+            "0x",
             ethers.utils.parseEther("-0.5"),
-            tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === weth.address)!)
+            tree.getHexProof(
+              slowFills.find(
+                (slowFill) =>
+                  slowFill.relayData.destinationToken === weth.address && slowFill.relayData.message === "0x"
+              )!
+            )
           )
         )
     ).to.changeEtherBalance(recipient, slowFillAmountPostFees.div(2));

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -30,6 +30,8 @@ export const totalPostModifiedFeesPct = toBN(oneHundredPct).sub(toBN(modifiedRel
 
 export const amountToRelayPreFees = toBN(amountToRelay).mul(toBN(oneHundredPct)).div(totalPostFeesPct);
 
+export const amountToDepositPostFees = toBN(amountToDeposit).mul(toBN(totalPostFeesPct)).div(oneHundredPct);
+
 export const amountToRelayPreModifiedFees = toBN(amountToRelay).mul(toBN(oneHundredPct)).div(totalPostModifiedFeesPct);
 
 export const amountToRelayPreLPFee = amountToRelayPreFees.mul(oneHundredPct.sub(realizedLpFeePct)).div(oneHundredPct);


### PR DESCRIPTION
Protects against edge cases where a `message` is sent multiple times to the `recipient`, who holds an unexpected amount of tokens.