### PR TITLE
improve(SpokePool): Pass fillCompleted and relayer to acrossMessageHandler

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -20,6 +20,8 @@ interface AcrossMessageHandler {
     function handleAcrossMessage(
         address tokenSent,
         uint256 amount,
+        bool fillCompleted,
+        address relayer,
         bytes memory message
     ) external;
 }
@@ -1244,6 +1246,8 @@ abstract contract SpokePool is
             AcrossMessageHandler(relayExecution.updatedRecipient).handleAcrossMessage(
                 relayData.destinationToken,
                 amountToSend,
+                relayFills[relayExecution.relayHash] >= relayData.amount,
+                msg.sender,
                 relayExecution.updatedMessage
             );
         }

--- a/contracts/test/AcrossMessageHandlerMock.sol
+++ b/contracts/test/AcrossMessageHandlerMock.sol
@@ -7,6 +7,8 @@ contract AcrossMessageHandlerMock is AcrossMessageHandler {
     function handleAcrossMessage(
         address tokenSent,
         uint256 amount,
+        bool fillCompleted,
+        address relayer,
         bytes memory message
     ) external override {}
 }

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -312,11 +312,37 @@ describe("SpokePool Relayer Logic", async function () {
     expect(acrossMessageHandler.handleAcrossMessage).to.have.been.calledOnceWith(
       weth.address,
       consts.amountToRelay,
+      false,
+      relayer.address,
+      "0x1234"
+    );
+  });
+  it("Handler is called with correct params", async function () {
+    const acrossMessageHandler = await createFake("AcrossMessageHandlerMock");
+    const { relayData } = getRelayHash(
+      depositor.address,
+      acrossMessageHandler.address,
+      consts.firstDepositId,
+      consts.originChainId,
+      consts.destinationChainId,
+      weth.address,
+      undefined,
+      undefined,
+      undefined,
       "0x1234"
     );
 
-    // The collateral should have not unwrapped to ETH and then transferred to recipient.
-    expect(await weth.balanceOf(acrossMessageHandler.address)).to.equal(consts.amountToRelay);
+    // Handler is called with full fill and relayer address.
+    await spokePool
+      .connect(depositor)
+      .fillRelay(...getFillRelayParams(relayData, relayData.amount, consts.destinationChainId));
+    expect(acrossMessageHandler.handleAcrossMessage).to.have.been.calledOnceWith(
+      weth.address,
+      relayData.amount.mul(consts.totalPostFeesPct).div(toBN(consts.oneHundredPct)),
+      true, // True because fill completed deposit.
+      depositor.address, // Custom relayer
+      "0x1234"
+    );
   });
   it("Self-relay transfers no tokens", async function () {
     const largeRelayAmount = consts.amountToSeedWallets.mul(100);

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -680,6 +680,8 @@ async function testfillRelayWithUpdatedDeposit(depositorAddress: string) {
   expect(acrossMessageHandler.handleAcrossMessage).to.have.been.calledOnceWith(
     relayData.destinationToken,
     amountActuallySent,
+    false,
+    relayer.address,
     updatedMessage
   );
 


### PR DESCRIPTION
Allow recipient to handle cases where a deposit with a message is sent in multiple partial fills, by different relayers.
Y
Signed-off-by: nicholaspai <npai.nyc@gmail.com>
