### PR TITLE
feat: Remove direct "hardhat" imports, update types in deploy/ scripts

### DIFF
--- a/deploy/001_deploy_hubpool.ts
+++ b/deploy/001_deploy_hubpool.ts
@@ -1,9 +1,8 @@
 import { L1_ADDRESS_MAP } from "./consts";
 
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import { DeployFunction } from "hardhat-deploy/types";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/001_deploy_hubpool.ts
+++ b/deploy/001_deploy_hubpool.ts
@@ -1,8 +1,9 @@
 import { L1_ADDRESS_MAP } from "./consts";
 
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/002_deploy_optimism_adapter.ts
+++ b/deploy/002_deploy_optimism_adapter.ts
@@ -1,9 +1,8 @@
 import { L1_ADDRESS_MAP } from "./consts";
 
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import { DeployFunction } from "hardhat-deploy/types";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/002_deploy_optimism_adapter.ts
+++ b/deploy/002_deploy_optimism_adapter.ts
@@ -1,8 +1,8 @@
 import { L1_ADDRESS_MAP } from "./consts";
-
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -1,7 +1,8 @@
 import { deployNewProxy } from "../utils";
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -1,8 +1,7 @@
-import "hardhat-deploy";
-import hre from "hardhat";
 import { deployNewProxy } from "../utils";
+import { DeployFunction } from "hardhat-deploy/types";
 
-const func = async function () {
+const func: DeployFunction = async function (hre: any) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/004_deploy_arbitrum_adapter.ts
+++ b/deploy/004_deploy_arbitrum_adapter.ts
@@ -1,7 +1,8 @@
 import { L1_ADDRESS_MAP } from "./consts";
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/004_deploy_arbitrum_adapter.ts
+++ b/deploy/004_deploy_arbitrum_adapter.ts
@@ -1,9 +1,7 @@
 import { L1_ADDRESS_MAP } from "./consts";
+import { DeployFunction } from "hardhat-deploy/types";
 
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
-
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -1,9 +1,8 @@
-import "hardhat-deploy";
-import hre from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
 import { deployNewProxy } from "../utils";
 
-const func = async function () {
+const func: DeployFunction = async function (hre: any) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -1,8 +1,9 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
 import { deployNewProxy } from "../utils";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/006_deploy_ethereum_adapter.ts
+++ b/deploy/006_deploy_ethereum_adapter.ts
@@ -1,7 +1,6 @@
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import { DeployFunction } from "hardhat-deploy/types";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
 

--- a/deploy/006_deploy_ethereum_adapter.ts
+++ b/deploy/006_deploy_ethereum_adapter.ts
@@ -1,6 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
 

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -1,11 +1,8 @@
-import "hardhat-deploy";
-import hre from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
 import { deployNewProxy } from "../utils";
 import { L1_ADDRESS_MAP } from "./consts";
 
-export async function printProxyVerificationInstructions() {}
-
-const func = async function () {
+const func: DeployFunction = async function () {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -1,8 +1,9 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { deployNewProxy } from "../utils";
 import { L1_ADDRESS_MAP } from "./consts";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function () {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/008_deploy_polygon_token_bridger_mainnet.ts
+++ b/deploy/008_deploy_polygon_token_bridger_mainnet.ts
@@ -1,9 +1,7 @@
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
-
+import { DeployFunction } from "hardhat-deploy/types";
 import { L1_ADDRESS_MAP, POLYGON_CHAIN_IDS } from "./consts";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/008_deploy_polygon_token_bridger_mainnet.ts
+++ b/deploy/008_deploy_polygon_token_bridger_mainnet.ts
@@ -1,7 +1,8 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L1_ADDRESS_MAP, POLYGON_CHAIN_IDS } from "./consts";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/009_deploy_polygon_adapter.ts
+++ b/deploy/009_deploy_polygon_adapter.ts
@@ -1,9 +1,7 @@
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
-
+import { DeployFunction } from "hardhat-deploy/types";
 import { L1_ADDRESS_MAP } from "./consts";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/009_deploy_polygon_adapter.ts
+++ b/deploy/009_deploy_polygon_adapter.ts
@@ -1,7 +1,8 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L1_ADDRESS_MAP } from "./consts";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/010_deploy_polygon_token_bridger_polygon.ts
+++ b/deploy/010_deploy_polygon_token_bridger_polygon.ts
@@ -1,9 +1,7 @@
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
-
+import { DeployFunction } from "hardhat-deploy/types";
 import { L1_ADDRESS_MAP } from "./consts";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/010_deploy_polygon_token_bridger_polygon.ts
+++ b/deploy/010_deploy_polygon_token_bridger_polygon.ts
@@ -1,7 +1,8 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L1_ADDRESS_MAP } from "./consts";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -1,9 +1,8 @@
-import "hardhat-deploy";
-import hre from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
 import { deployNewProxy } from "../utils";
 
-const func = async function () {
+const func: DeployFunction = async function (hre: any) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -1,8 +1,9 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
 import { deployNewProxy } from "../utils";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/012_deploy_boba_adapter.ts
+++ b/deploy/012_deploy_boba_adapter.ts
@@ -1,7 +1,8 @@
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { L1_ADDRESS_MAP } from "./consts";
 import { DeployFunction } from "hardhat-deploy/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/012_deploy_boba_adapter.ts
+++ b/deploy/012_deploy_boba_adapter.ts
@@ -1,9 +1,7 @@
 import { L1_ADDRESS_MAP } from "./consts";
+import { DeployFunction } from "hardhat-deploy/types";
 
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
-
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/013_deploy_boba_spokepool.ts
+++ b/deploy/013_deploy_boba_spokepool.ts
@@ -1,8 +1,7 @@
-import "hardhat-deploy";
-import hre from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
 import { deployNewProxy } from "../utils";
 
-const func = async function () {
+const func: DeployFunction = async function (hre: any) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/013_deploy_boba_spokepool.ts
+++ b/deploy/013_deploy_boba_spokepool.ts
@@ -1,7 +1,8 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { deployNewProxy } from "../utils";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/014_deploy_config_store.ts
+++ b/deploy/014_deploy_config_store.ts
@@ -1,7 +1,6 @@
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import { DeployFunction } from "hardhat-deploy/types";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
 

--- a/deploy/014_deploy_config_store.ts
+++ b/deploy/014_deploy_config_store.ts
@@ -1,6 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
 

--- a/deploy/015_deploy_zksync_adapter.ts
+++ b/deploy/015_deploy_zksync_adapter.ts
@@ -1,7 +1,6 @@
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import { DeployFunction } from "hardhat-deploy/types";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts } = hre;
 
   const { deploy } = deployments;

--- a/deploy/015_deploy_zksync_adapter.ts
+++ b/deploy/015_deploy_zksync_adapter.ts
@@ -1,6 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
 
   const { deploy } = deployments;

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -1,9 +1,8 @@
-import "hardhat-deploy";
-import hre from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
 import { deployNewProxy } from "../utils";
 
-const func = async function () {
+const func: DeployFunction = async function (hre: any) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -1,8 +1,9 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
 import { deployNewProxy } from "../utils";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
   const chainId = await hre.getChainId();
   console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);

--- a/deploy/017_deploy_ethereum_merkle_distributor.ts
+++ b/deploy/017_deploy_ethereum_merkle_distributor.ts
@@ -1,7 +1,7 @@
-import "hardhat-deploy";
+import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
 

--- a/deploy/017_deploy_ethereum_merkle_distributor.ts
+++ b/deploy/017_deploy_ethereum_merkle_distributor.ts
@@ -1,7 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
 

--- a/deploy/018_deploy_arbitrum_rescueadapter.ts
+++ b/deploy/018_deploy_arbitrum_rescueadapter.ts
@@ -1,7 +1,8 @@
 import { L1_ADDRESS_MAP } from "./consts";
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/018_deploy_arbitrum_rescueadapter.ts
+++ b/deploy/018_deploy_arbitrum_rescueadapter.ts
@@ -1,9 +1,7 @@
 import { L1_ADDRESS_MAP } from "./consts";
+import { DeployFunction } from "hardhat-deploy/types";
 
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
-
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/019_deploy_bond_token.ts
+++ b/deploy/019_deploy_bond_token.ts
@@ -1,6 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
   const { deployer } = await getNamedAccounts();
 

--- a/deploy/019_deploy_bond_token.ts
+++ b/deploy/019_deploy_bond_token.ts
@@ -1,7 +1,6 @@
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import { DeployFunction } from "hardhat-deploy/types";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts } = hre;
   const { deployer } = await getNamedAccounts();
 

--- a/deploy/020_deploy_arbitrum_sendtoken_adapter.ts
+++ b/deploy/020_deploy_arbitrum_sendtoken_adapter.ts
@@ -1,7 +1,8 @@
 import { L1_ADDRESS_MAP } from "./consts";
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/020_deploy_arbitrum_sendtoken_adapter.ts
+++ b/deploy/020_deploy_arbitrum_sendtoken_adapter.ts
@@ -1,9 +1,7 @@
 import { L1_ADDRESS_MAP } from "./consts";
+import { DeployFunction } from "hardhat-deploy/types";
 
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
-
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts, getChainId } = hre;
   const { deploy } = deployments;
 

--- a/deploy/021_deploy_erc1155.ts
+++ b/deploy/021_deploy_erc1155.ts
@@ -1,7 +1,6 @@
-import "hardhat-deploy";
-import { HardhatRuntimeEnvironment } from "hardhat/types/runtime";
+import { DeployFunction } from "hardhat-deploy/types";
 
-const func = async function (hre: HardhatRuntimeEnvironment) {
+const func: DeployFunction = async function (hre: any) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
 

--- a/deploy/021_deploy_erc1155.ts
+++ b/deploy/021_deploy_erc1155.ts
@@ -1,6 +1,7 @@
 import { DeployFunction } from "hardhat-deploy/types";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { deployments, getNamedAccounts } = hre;
   const { deploy } = deployments;
 

--- a/deploy/022_upgrade_spokepool.ts
+++ b/deploy/022_upgrade_spokepool.ts
@@ -1,8 +1,9 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { getContractFactory } from "../utils";
 import * as deployments from "../deployments/deployments.json";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
 
-const func: DeployFunction = async function (hre: any) {
+const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   const { upgrades, run, getChainId, getNamedAccounts } = hre;
   const { deployer } = await getNamedAccounts();
 

--- a/deploy/022_upgrade_spokepool.ts
+++ b/deploy/022_upgrade_spokepool.ts
@@ -1,9 +1,8 @@
-import "hardhat-deploy";
-import hre from "hardhat";
+import { DeployFunction } from "hardhat-deploy/types";
 import { getContractFactory } from "../utils";
 import * as deployments from "../deployments/deployments.json";
 
-const func = async function () {
+const func: DeployFunction = async function (hre: any) {
   const { upgrades, run, getChainId, getNamedAccounts } = hre;
   const { deployer } = await getNamedAccounts();
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/test/fixtures/MerkleLib.Fixture.ts
+++ b/test/fixtures/MerkleLib.Fixture.ts
@@ -1,10 +1,7 @@
-import { Contract, getContractFactory } from "../../utils/utils";
-import hre from "hardhat";
+import { Contract, getContractFactory, hre } from "../../utils/utils";
 
-export const merkleLibFixture: () => Promise<{ merkleLibTest: Contract }> = hre.deployments.createFixture(
-  async ({ deployments }) => {
-    const [signer] = await hre.ethers.getSigners();
-    const merkleLibTest = await (await getContractFactory("MerkleLibTest", { signer })).deploy();
-    return { merkleLibTest };
-  }
-);
+export const merkleLibFixture: () => Promise<{ merkleLibTest: Contract }> = hre.deployments.createFixture(async () => {
+  const [signer] = await hre.ethers.getSigners();
+  const merkleLibTest = await (await getContractFactory("MerkleLibTest", { signer })).deploy();
+  return { merkleLibTest };
+});

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -5,11 +5,11 @@ import * as chai from "chai";
 import { getBytecode, getAbi } from "@uma/contracts-node";
 import * as optimismContracts from "@eth-optimism/contracts";
 import { smock, FakeContract } from "@defi-wonderland/smock";
-chai.use(smock.matchers);
-import hre from "hardhat";
-import { ethers } from "hardhat";
-import { BigNumber, Signer, Contract, ContractFactory } from "ethers";
 import { FactoryOptions } from "hardhat/types";
+import { ethers, hre } from "..";
+
+chai.use(smock.matchers);
+const { BigNumber, Signer, Contract, ContractFactory } = ethers;
 
 export { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -6,11 +6,12 @@ import { getBytecode, getAbi } from "@uma/contracts-node";
 import * as optimismContracts from "@eth-optimism/contracts";
 import { smock, FakeContract } from "@defi-wonderland/smock";
 import { FactoryOptions } from "hardhat/types";
-chai.use(smock.matchers);
 import hre from "hardhat";
 import { ethers } from "hardhat";
 import { BigNumber, Signer, Contract, ContractFactory } from "ethers";
 export { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
+
+chai.use(smock.matchers);
 
 function isFactoryOptions(signerOrFactoryOptions: Signer | FactoryOptions): signerOrFactoryOptions is FactoryOptions {
   return "signer" in signerOrFactoryOptions || "libraries" in signerOrFactoryOptions;

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -6,11 +6,10 @@ import { getBytecode, getAbi } from "@uma/contracts-node";
 import * as optimismContracts from "@eth-optimism/contracts";
 import { smock, FakeContract } from "@defi-wonderland/smock";
 import { FactoryOptions } from "hardhat/types";
-import { ethers, hre } from "..";
-
 chai.use(smock.matchers);
-const { BigNumber, Signer, Contract, ContractFactory } = ethers;
-
+import hre from "hardhat";
+import { ethers } from "hardhat";
+import { BigNumber, Signer, Contract, ContractFactory } from "ethers";
 export { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
 
 function isFactoryOptions(signerOrFactoryOptions: Signer | FactoryOptions): signerOrFactoryOptions is FactoryOptions {


### PR DESCRIPTION
The HRE should only be constructed once, and for the deploy scripts we should try to load that existing object