### PR TITLE
refactor(UBA): sideload HRE environment variable

### DIFF
--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -1,4 +1,4 @@
-import { deployNewProxy } from "../utils";
+import { deployNewProxy } from "../utils/utils.hre";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -1,6 +1,6 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
-import { deployNewProxy } from "../utils";
+import { deployNewProxy } from "../utils/utils.hre";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -1,5 +1,5 @@
 import { DeployFunction } from "hardhat-deploy/types";
-import { deployNewProxy } from "../utils";
+import { deployNewProxy } from "../utils/utils.hre";
 import { L1_ADDRESS_MAP } from "./consts";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -1,6 +1,6 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
-import { deployNewProxy } from "../utils";
+import { deployNewProxy } from "../utils/utils.hre";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {

--- a/deploy/013_deploy_boba_spokepool.ts
+++ b/deploy/013_deploy_boba_spokepool.ts
@@ -1,5 +1,5 @@
 import { DeployFunction } from "hardhat-deploy/types";
-import { deployNewProxy } from "../utils";
+import { deployNewProxy } from "../utils/utils.hre";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -1,6 +1,6 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
-import { deployNewProxy } from "../utils";
+import { deployNewProxy } from "../utils/utils.hre";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {

--- a/scripts/mintERC1155.ts
+++ b/scripts/mintERC1155.ts
@@ -1,7 +1,8 @@
-import { getContractFactory, ethers, hre } from "../utils/utils";
+import { getContractFactory, ethers } from "../utils/utils";
 import { readFileSync } from "fs";
 import path from "path";
 import { getNodeUrl } from "@uma/common";
+import { hre } from "../utils/utils.hre";
 
 const RECIPIENTS_CHUNK_SIZE = 100; // TODO: Still need to figure out which size is optimal
 

--- a/scripts/setERC1155Metadata.ts
+++ b/scripts/setERC1155Metadata.ts
@@ -1,4 +1,5 @@
-import { getContractFactory, ethers, hre } from "../utils/utils";
+import { getContractFactory, ethers } from "../utils/utils";
+import { hre } from "../utils/utils.hre";
 import { readFileSync } from "fs";
 import path from "path";
 import { CID } from "multiformats/cid";

--- a/test/HubPool.Admin.ts
+++ b/test/HubPool.Admin.ts
@@ -1,7 +1,24 @@
-import { getContractFactory, SignerWithAddress, seedWallet, expect } from "../utils/utils";
-import { Contract, ethers, randomAddress, utf8ToHex } from "../utils/utils";
-import { originChainId, destinationChainId, bondAmount, zeroAddress, mockTreeRoot } from "./constants";
-import { mockSlowRelayRoot, finalFeeUsdc, finalFee, totalBond } from "./constants";
+import {
+  getContractFactory,
+  SignerWithAddress,
+  seedWallet,
+  expect,
+  Contract,
+  ethers,
+  randomAddress,
+  utf8ToHex,
+} from "../utils/utils";
+import {
+  originChainId,
+  destinationChainId,
+  bondAmount,
+  zeroAddress,
+  mockTreeRoot,
+  mockSlowRelayRoot,
+  finalFeeUsdc,
+  finalFee,
+  totalBond,
+} from "./constants";
 import { hubPoolFixture } from "./fixtures/HubPool.Fixture";
 
 let hubPool: Contract, weth: Contract, usdc: Contract;

--- a/test/MerkleLib.Proofs.ts
+++ b/test/MerkleLib.Proofs.ts
@@ -1,8 +1,16 @@
 import { PoolRebalanceLeaf, RelayerRefundLeaf } from "./MerkleLib.utils";
 import { merkleLibFixture } from "./fixtures/MerkleLib.Fixture";
 import { MerkleTree, EMPTY_MERKLE_ROOT } from "../utils/MerkleTree";
-import { expect, randomBigNumber, randomAddress, getParamType, defaultAbiCoder } from "../utils/utils";
-import { keccak256, Contract, BigNumber } from "../utils/utils";
+import {
+  expect,
+  randomBigNumber,
+  randomAddress,
+  getParamType,
+  defaultAbiCoder,
+  keccak256,
+  Contract,
+  BigNumber,
+} from "../utils/utils";
 
 let merkleLibTest: Contract;
 

--- a/test/MerkleLib.utils.ts
+++ b/test/MerkleLib.utils.ts
@@ -1,7 +1,7 @@
 import { getParamType, expect, BigNumber, Contract, defaultAbiCoder, keccak256, toBNWei } from "../utils/utils";
 import { repaymentChainId, amountToReturn } from "./constants";
 import { MerkleTree } from "../utils/MerkleTree";
-import { RelayData, SlowFill } from "./fixtures/SpokePool.Fixture";
+import { SlowFill } from "./fixtures/SpokePool.Fixture";
 export interface PoolRebalanceLeaf {
   chainId: BigNumber;
   groupIndex: BigNumber;

--- a/test/SpokePool.Admin.ts
+++ b/test/SpokePool.Admin.ts
@@ -1,4 +1,5 @@
-import { expect, ethers, Contract, SignerWithAddress, getContractFactory, hre } from "../utils/utils";
+import { expect, ethers, Contract, SignerWithAddress, getContractFactory } from "../utils/utils";
+import { hre } from "../utils/utils.hre";
 import { spokePoolFixture } from "./fixtures/SpokePool.Fixture";
 import { destinationChainId, mockRelayerRefundRoot, mockSlowRelayRoot } from "./constants";
 

--- a/test/SpokePool.Upgrades.ts
+++ b/test/SpokePool.Upgrades.ts
@@ -1,4 +1,5 @@
-import { expect, ethers, Contract, SignerWithAddress, hre, randomAddress } from "../utils/utils";
+import { expect, ethers, Contract, SignerWithAddress, randomAddress } from "../utils/utils";
+import { hre } from "../utils/utils.hre";
 import { spokePoolFixture } from "./fixtures/SpokePool.Fixture";
 
 let spokePool: Contract;

--- a/test/chain-adapters/Arbitrum_Adapter.ts
+++ b/test/chain-adapters/Arbitrum_Adapter.ts
@@ -9,8 +9,10 @@ import {
   toWei,
   defaultAbiCoder,
   toBN,
+  getContractFactory,
+  seedWallet,
+  randomAddress,
 } from "../../utils/utils";
-import { getContractFactory, seedWallet, randomAddress } from "../../utils/utils";
 import { hubPoolFixture, enableTokensForLP } from "../fixtures/HubPool.Fixture";
 import { constructSingleChainTree } from "../MerkleLib.utils";
 

--- a/test/chain-adapters/Ethereum_Adapter.ts
+++ b/test/chain-adapters/Ethereum_Adapter.ts
@@ -1,6 +1,14 @@
 import * as consts from "../constants";
-import { ethers, expect, Contract, SignerWithAddress, randomAddress, hre } from "../../utils/utils";
-import { getContractFactory, seedWallet } from "../../utils/utils";
+import {
+  ethers,
+  expect,
+  Contract,
+  SignerWithAddress,
+  randomAddress,
+  getContractFactory,
+  seedWallet,
+} from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { hubPoolFixture, enableTokensForLP } from "../fixtures/HubPool.Fixture";
 import { constructSingleChainTree } from "../MerkleLib.utils";
 

--- a/test/chain-adapters/Optimism_Adapter.ts
+++ b/test/chain-adapters/Optimism_Adapter.ts
@@ -1,6 +1,15 @@
 import { sampleL2Gas, amountToLp, mockTreeRoot, refundProposalLiveness, bondAmount } from "./../constants";
-import { ethers, expect, Contract, FakeContract, SignerWithAddress, createFake, hre } from "../../utils/utils";
-import { getContractFactory, seedWallet, randomAddress } from "../../utils/utils";
+import {
+  ethers,
+  expect,
+  Contract,
+  FakeContract,
+  SignerWithAddress,
+  createFake,
+  getContractFactory,
+  seedWallet,
+  randomAddress,
+} from "../../utils/utils";
 import { hubPoolFixture, enableTokensForLP } from "../fixtures/HubPool.Fixture";
 import { constructSingleChainTree } from "../MerkleLib.utils";
 

--- a/test/chain-adapters/Polygon_Adapter.ts
+++ b/test/chain-adapters/Polygon_Adapter.ts
@@ -1,6 +1,16 @@
 import { amountToLp, mockTreeRoot, refundProposalLiveness, bondAmount, mockSlowRelayRoot } from "./../constants";
-import { ethers, expect, Contract, FakeContract, SignerWithAddress } from "../../utils/utils";
-import { createFake, getContractFactory, seedWallet, randomAddress, hre } from "../../utils/utils";
+import {
+  ethers,
+  expect,
+  Contract,
+  FakeContract,
+  SignerWithAddress,
+  createFake,
+  getContractFactory,
+  seedWallet,
+  randomAddress,
+} from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { hubPoolFixture, enableTokensForLP } from "../fixtures/HubPool.Fixture";
 import { constructSingleChainTree } from "../MerkleLib.utils";
 import { TokenRolesEnum } from "@uma/common";

--- a/test/chain-specific-spokepools/Arbitrum_SpokePool.ts
+++ b/test/chain-specific-spokepools/Arbitrum_SpokePool.ts
@@ -1,6 +1,17 @@
 import { mockTreeRoot, amountToReturn, amountHeldByPool, zeroAddress } from "../constants";
-import { ethers, expect, Contract, FakeContract, SignerWithAddress, createFake, toWei } from "../../utils/utils";
-import { getContractFactory, seedContract, avmL1ToL2Alias, hre } from "../../utils/utils";
+import {
+  ethers,
+  expect,
+  Contract,
+  FakeContract,
+  SignerWithAddress,
+  createFake,
+  toWei,
+  getContractFactory,
+  seedContract,
+  avmL1ToL2Alias,
+} from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { hubPoolFixture } from "../fixtures/HubPool.Fixture";
 import { constructSingleRelayerRefundTree } from "../MerkleLib.utils";
 

--- a/test/chain-specific-spokepools/Ethereum_SpokePool.ts
+++ b/test/chain-specific-spokepools/Ethereum_SpokePool.ts
@@ -1,6 +1,6 @@
 import { mockTreeRoot, amountToReturn, amountHeldByPool } from "../constants";
-import { ethers, expect, Contract, SignerWithAddress, hre } from "../../utils/utils";
-import { getContractFactory, seedContract } from "../../utils/utils";
+import { ethers, expect, Contract, SignerWithAddress, getContractFactory, seedContract } from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { hubPoolFixture } from "../fixtures/HubPool.Fixture";
 import { constructSingleRelayerRefundTree } from "../MerkleLib.utils";
 

--- a/test/chain-specific-spokepools/Optimism_SpokePool.ts
+++ b/test/chain-specific-spokepools/Optimism_SpokePool.ts
@@ -1,6 +1,17 @@
 import { mockTreeRoot, amountToReturn, amountHeldByPool } from "../constants";
-import { ethers, expect, Contract, FakeContract, SignerWithAddress, createFake, toWei } from "../../utils/utils";
-import { getContractFactory, seedContract, hre } from "../../utils/utils";
+import {
+  ethers,
+  expect,
+  Contract,
+  FakeContract,
+  SignerWithAddress,
+  createFake,
+  toWei,
+  getContractFactory,
+  seedContract,
+} from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
+
 import { hubPoolFixture } from "../fixtures/HubPool.Fixture";
 import { constructSingleRelayerRefundTree } from "../MerkleLib.utils";
 

--- a/test/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -1,6 +1,18 @@
 import { mockTreeRoot, amountToReturn, amountHeldByPool, zeroAddress, TokenRolesEnum } from "../constants";
-import { ethers, expect, Contract, SignerWithAddress, getContractFactory, createFake } from "../../utils/utils";
-import { seedContract, toWei, randomBigNumber, seedWallet, FakeContract, hre } from "../../utils/utils";
+import {
+  ethers,
+  expect,
+  Contract,
+  SignerWithAddress,
+  getContractFactory,
+  createFake,
+  seedContract,
+  toWei,
+  randomBigNumber,
+  seedWallet,
+  FakeContract,
+} from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { hubPoolFixture } from "../fixtures/HubPool.Fixture";
 import { constructSingleRelayerRefundTree } from "../MerkleLib.utils";
 import { randomBytes } from "crypto";

--- a/test/chain-specific-spokepools/Succinct_SpokePool.ts
+++ b/test/chain-specific-spokepools/Succinct_SpokePool.ts
@@ -1,4 +1,5 @@
-import { ethers, expect, Contract, SignerWithAddress, getContractFactory, hre } from "../../utils/utils";
+import { ethers, expect, Contract, SignerWithAddress, getContractFactory } from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { hubPoolFixture } from "../fixtures/HubPool.Fixture";
 
 let succinctSpokePool: Contract, timer: Contract, weth: Contract;

--- a/test/fixtures/BondToken.Fixture.ts
+++ b/test/fixtures/BondToken.Fixture.ts
@@ -1,4 +1,5 @@
-import { Contract, getContractFactory, hre } from "../../utils/utils";
+import { Contract, getContractFactory } from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { hubPoolFixture } from "./HubPool.Fixture";
 
 export const bondTokenFixture = hre.deployments.createFixture(async ({ ethers }, hubPool?: Contract) => {

--- a/test/fixtures/HubPool.Fixture.ts
+++ b/test/fixtures/HubPool.Fixture.ts
@@ -1,4 +1,5 @@
-import { getContractFactory, randomAddress, hre, Contract, Signer } from "../../utils/utils";
+import { getContractFactory, randomAddress, Contract, Signer } from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { originChainId, bondAmount, refundProposalLiveness, finalFee } from "../constants";
 import { repaymentChainId, finalFeeUsdc, TokenRolesEnum } from "../constants";
 import { umaEcosystemFixture } from "./UmaEcosystem.Fixture";

--- a/test/fixtures/MerkleLib.Fixture.ts
+++ b/test/fixtures/MerkleLib.Fixture.ts
@@ -1,4 +1,5 @@
-import { Contract, getContractFactory, hre } from "../../utils/utils";
+import { Contract, getContractFactory } from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 
 export const merkleLibFixture: () => Promise<{ merkleLibTest: Contract }> = hre.deployments.createFixture(async () => {
   const [signer] = await hre.ethers.getSigners();

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -1,12 +1,6 @@
-import {
-  getContractFactory,
-  SignerWithAddress,
-  Contract,
-  hre,
-  ethers,
-  BigNumber,
-  defaultAbiCoder,
-} from "../../utils/utils";
+import { getContractFactory, SignerWithAddress, Contract, ethers, BigNumber, defaultAbiCoder } from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
+
 import * as consts from "../constants";
 
 export const spokePoolFixture = hre.deployments.createFixture(async ({ ethers }) => {

--- a/test/fixtures/UmaEcosystem.Fixture.ts
+++ b/test/fixtures/UmaEcosystem.Fixture.ts
@@ -1,4 +1,5 @@
-import { getContractFactory, utf8ToHex, hre, Contract } from "../../utils/utils";
+import { getContractFactory, utf8ToHex, Contract } from "../../utils/utils";
+import { hre } from "../../utils/utils.hre";
 import { refundProposalLiveness, zeroRawValue, identifier } from "../constants";
 import { interfaceName } from "@uma/common";
 

--- a/test/gas-analytics/HubPool.RootExecution.ts
+++ b/test/gas-analytics/HubPool.RootExecution.ts
@@ -1,10 +1,22 @@
-import { toBNWei, toBN, SignerWithAddress, seedWallet, Contract, ethers, hre, expect } from "../../utils/utils";
-import { getContractFactory, BigNumber, randomAddress, createRandomBytes32 } from "../../utils/utils";
+import {
+  toBNWei,
+  toBN,
+  SignerWithAddress,
+  seedWallet,
+  Contract,
+  ethers,
+  expect,
+  getContractFactory,
+  BigNumber,
+  randomAddress,
+  createRandomBytes32,
+} from "../../utils/utils";
 import { deployErc20 } from "./utils";
 import * as consts from "../constants";
 import { hubPoolFixture, enableTokensForLP } from "../fixtures/HubPool.Fixture";
 import { buildPoolRebalanceLeafTree, buildPoolRebalanceLeaves, PoolRebalanceLeaf } from "../MerkleLib.utils";
 import { MerkleTree } from "../../utils/MerkleTree";
+import { hre } from "../../utils/utils.hre";
 
 require("dotenv").config();
 

--- a/test/merkle-distributor/MerkleDistributor.ts
+++ b/test/merkle-distributor/MerkleDistributor.ts
@@ -1,16 +1,6 @@
 /* eslint-disable no-unused-expressions */
 
-import {
-  ethers,
-  getContractFactory,
-  SignerWithAddress,
-  Contract,
-  toWei,
-  toBN,
-  expect,
-  keccak256,
-  defaultAbiCoder,
-} from "../../utils/utils";
+import { ethers, getContractFactory, SignerWithAddress, Contract, toWei, toBN, expect } from "../../utils/utils";
 import { deployErc20 } from "../gas-analytics/utils";
 import { MAX_UINT_VAL, MerkleTree } from "@uma/common";
 

--- a/utils/utils.hre.ts
+++ b/utils/utils.hre.ts
@@ -1,0 +1,22 @@
+import { getContractFactory } from "./utils";
+import hre from "hardhat";
+
+export async function deployNewProxy(name: string, args: (number | string)[]): Promise<void> {
+  const { run, upgrades } = hre;
+
+  const proxy = await upgrades.deployProxy(await getContractFactory(name, {}), args, { kind: "uups" });
+  const instance = await proxy.deployed();
+  console.log(`New ${name} proxy deployed @ ${instance.address}`);
+  const implementationAddress = await upgrades.erc1967.getImplementationAddress(instance.address);
+  console.log(`${name} implementation deployed @ ${implementationAddress}`);
+
+  // hardhat-upgrades overrides the `verify` task that ships with `hardhat` so that if the address passed
+  // is a proxy, hardhat will first verify the implementation and then the proxy and also link the proxy
+  // to the implementation's ABI on etherscan.
+  // https://docs.openzeppelin.com/upgrades-plugins/1.x/api-hardhat-upgrades#verify
+  await run("verify:verify", {
+    address: instance.address,
+  });
+}
+
+export { hre };

--- a/utils/utils.ts
+++ b/utils/utils.ts
@@ -6,7 +6,6 @@ import { getBytecode, getAbi } from "@uma/contracts-node";
 import * as optimismContracts from "@eth-optimism/contracts";
 import { smock, FakeContract } from "@defi-wonderland/smock";
 import { FactoryOptions } from "hardhat/types";
-import hre from "hardhat";
 import { ethers } from "hardhat";
 import { BigNumber, Signer, Contract, ContractFactory } from "ethers";
 export { SignerWithAddress } from "@nomiclabs/hardhat-ethers/signers";
@@ -54,24 +53,6 @@ export async function getContractFactory(
   }
 }
 
-export async function deployNewProxy(name: string, args: (number | string)[]): Promise<void> {
-  const { run, upgrades } = hre;
-
-  const proxy = await upgrades.deployProxy(await getContractFactory(name, {}), args, { kind: "uups" });
-  const instance = await proxy.deployed();
-  console.log(`New ${name} proxy deployed @ ${instance.address}`);
-  const implementationAddress = await upgrades.erc1967.getImplementationAddress(instance.address);
-  console.log(`${name} implementation deployed @ ${implementationAddress}`);
-
-  // hardhat-upgrades overrides the `verify` task that ships with `hardhat` so that if the address passed
-  // is a proxy, hardhat will first verify the implementation and then the proxy and also link the proxy
-  // to the implementation's ABI on etherscan.
-  // https://docs.openzeppelin.com/upgrades-plugins/1.x/api-hardhat-upgrades#verify
-  await run("verify:verify", {
-    address: instance.address,
-  });
-}
-
 // Arbitrum does not export any of their artifacts nicely, so we have to do this manually. The methods that follow can
 // be re-used if we end up requiring to import contract artifacts from other projects that dont export cleanly.
 function getArbitrumArtifact(contractName: string) {
@@ -88,7 +69,7 @@ function getArbitrumArtifact(contractName: string) {
 
 // Fetch the artifact from the publish package's artifacts directory.
 function getLocalArtifact(contractName: string) {
-  const artifactsPath = `${__dirname}/../../artifacts/contracts`;
+  const artifactsPath = path.join(__dirname, "../../artifacts/contracts");
   return findArtifactFromPath(contractName, artifactsPath);
 }
 
@@ -201,4 +182,4 @@ function avmL1ToL2Alias(l1Address: string) {
 
 const { defaultAbiCoder, keccak256 } = ethers.utils;
 
-export { avmL1ToL2Alias, expect, Contract, ethers, hre, BigNumber, defaultAbiCoder, keccak256, FakeContract, Signer };
+export { avmL1ToL2Alias, expect, Contract, ethers, BigNumber, defaultAbiCoder, keccak256, FakeContract, Signer };


### PR DESCRIPTION
This change essentially side-loads the HRE variables to prevent the need to directly interface with the Hardhat Runtime Environment.