### PR TITLE
fix: Export utils.hre

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,4 @@
 export * from "./utils";
+export * from "./utils.hre";
 export * from "./MerkleTree";
 export * from "./constants";


### PR DESCRIPTION
relayer-v2 is dependent on these exports.

FWIW, I'm not 100% sure that this isn't just re-introducing the problem we previously had over in the scraper api. Would be good to discuss :+1: 