### PR TITLE
fix: [N02] Add docstring

### DIFF
--- a/contracts/SpokePoolVerifier.sol
+++ b/contracts/SpokePoolVerifier.sol
@@ -10,6 +10,24 @@ import "./interfaces/SpokePoolInterface.sol";
 contract SpokePoolVerifier {
     using Address for address;
 
+    /**
+     * @notice Passthrough function to `deposit()` on the SpokePool contract.
+     * @dev Protects the caller from losing their ETH (or other native token) by reverting if the SpokePool address
+     * they intended to call does not exist on this chain. Because this contract can be deployed at the same address
+     * everywhere callers should be protected even if the transaction is submitted to an unintended network.
+     * This contract should only be used for native token deposits, as this problem only exists for native tokens.
+     * @param spokePool Address of the SpokePool contract that the user is intending to call.
+     * @param recipient Address to receive funds at on destination chain.
+     * @param originToken Token to lock into this contract to initiate deposit.
+     * @param amount Amount of tokens to deposit. Will be amount of tokens to receive less fees.
+     * @param destinationChainId Denotes network where user will receive funds from SpokePool by a relayer.
+     * @param relayerFeePct % of deposit amount taken out to incentivize a fast relayer.
+     * @param quoteTimestamp Timestamp used by relayers to compute this deposit's realizedLPFeePct which is paid
+     * to LP pool on HubPool.
+     * @param message Arbitrary data that can be used to pass additional information to the recipient along with the tokens.
+     * Note: this is intended to be used to pass along instructions for how a contract should use or allocate the tokens.
+     * @param maxCount used to protect the depositor from frontrunning to guarantee their quote remains valid.
+     */
     function deposit(
         SpokePoolInterface spokePool,
         address recipient,


### PR DESCRIPTION
This adds a docstring to the deposit method on the SpokePoolVerifier contract.