### PR TITLE
fix: [N-03] Lack of Documentation (removed hardcoded refund address)

### DIFF
--- a/contracts/chain-adapters/ZkSync_Adapter.sol
+++ b/contracts/chain-adapters/ZkSync_Adapter.sol
@@ -82,7 +82,7 @@ contract ZkSync_Adapter is AdapterInterface {
     // This address receives any remaining fee after an L1 to L2 transaction completes.
     // If refund recipient = address(0) then L2 msg.sender is used, unelss msg.sender is a contract then its address
     // gets aliased.
-    address public constant l2RefundAddress = 0x428AB2BA90Eba0a4Be7aF34C9Ac451ab061AC010;
+    address public immutable l2RefundAddress;
 
     // Hardcode the following ZkSync system contract addresses to save gas on construction. This adapter can be
     // redeployed in the event that the following addresses change.
@@ -101,9 +101,11 @@ contract ZkSync_Adapter is AdapterInterface {
     /**
      * @notice Constructs new Adapter.
      * @param _l1Weth WETH address on L1.
+     * @param _l2RefundAddress address that recieves excess gas refunds on L2.
      */
-    constructor(WETH9Interface _l1Weth) {
+    constructor(WETH9Interface _l1Weth, address _l2RefundAddress) {
         l1Weth = _l1Weth;
+        l2RefundAddress = _l2RefundAddress;
     }
 
     /**

--- a/deploy/015_deploy_zksync_adapter.ts
+++ b/deploy/015_deploy_zksync_adapter.ts
@@ -1,18 +1,21 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { L1_ADDRESS_MAP } from "./consts";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const { deployments, getNamedAccounts } = hre;
+  const { deployments, getNamedAccounts, getChainId } = hre;
 
   const { deploy } = deployments;
 
   const { deployer } = await getNamedAccounts();
+  const chainId = parseInt(await getChainId());
 
   await deploy("ZkSync_Adapter", {
     from: deployer,
     log: true,
     skipIfAlreadyDeployed: true,
-    args: [],
+    // Most common across dataworker set as the refund address, but changeable by whoever runs the script.
+    args: [L1_ADDRESS_MAP[chainId].weth, "0x428AB2BA90Eba0a4Be7aF34C9Ac451ab061AC010"],
   });
 };
 

--- a/test/chain-adapters/ZkSync_Adapter.ts
+++ b/test/chain-adapters/ZkSync_Adapter.ts
@@ -17,7 +17,10 @@ import { smock } from "@defi-wonderland/smock";
 
 let hubPool: Contract, zkSyncAdapter: Contract, weth: Contract, dai: Contract, timer: Contract, mockSpoke: Contract;
 let l2Weth: string, l2Dai: string, mainnetWeth: FakeContract;
-let owner: SignerWithAddress, dataWorker: SignerWithAddress, liquidityProvider: SignerWithAddress;
+let owner: SignerWithAddress,
+  dataWorker: SignerWithAddress,
+  liquidityProvider: SignerWithAddress,
+  refundAddress: SignerWithAddress;
 let zkSync: FakeContract, zkSyncErc20Bridge: FakeContract;
 
 const zkSyncChainId = 324;
@@ -73,7 +76,7 @@ const l2TransactionBaseCost = toWei("0.0001");
 
 describe("ZkSync Chain Adapter", function () {
   beforeEach(async function () {
-    [owner, dataWorker, liquidityProvider] = await ethers.getSigners();
+    [owner, dataWorker, liquidityProvider, refundAddress] = await ethers.getSigners();
     ({ weth, dai, l2Weth, l2Dai, hubPool, mockSpoke, timer } = await hubPoolFixture());
     await seedWallet(dataWorker, [dai], weth, amountToLp);
     await seedWallet(liquidityProvider, [dai], weth, amountToLp.mul(10));
@@ -93,7 +96,9 @@ describe("ZkSync Chain Adapter", function () {
       address: "0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063",
     });
 
-    zkSyncAdapter = await (await getContractFactory("ZkSync_Adapter", owner)).deploy(weth.address);
+    zkSyncAdapter = await (
+      await getContractFactory("ZkSync_Adapter", owner)
+    ).deploy(weth.address, refundAddress.address);
 
     // Seed the HubPool some funds so it can send L1->L2 messages.
     await hubPool.connect(liquidityProvider).loadEthForL2Calls({ value: toWei("100000") });


### PR DESCRIPTION
This PR removes the hardcoded refund address for zkSync, replaces it with an immutable value, and adds a default address in the deployment script that is the most common dataworker address.