### PR TITLE
fix: [M-01] zkSync limits

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -2,6 +2,7 @@
   "extends": "solhint:recommended",
   "rules": {
     "compiler-version": ["error", "^0.8.0"],
-    "func-visibility": ["warn", { "ignoreConstructors": true }]
+    "func-visibility": ["warn", { "ignoreConstructors": true }],
+    "const-name-snakecase": "off"
   }
 }

--- a/contracts/chain-adapters/ZkSync_Adapter.sol
+++ b/contracts/chain-adapters/ZkSync_Adapter.sol
@@ -53,6 +53,63 @@ interface ZkBridgeLike {
     ) external payable returns (bytes32 txHash);
 }
 
+// Note: this contract just forwards the calls from the HubPool to ZkSync to avoid limits.
+// A modified ZKSync_Adapter should be deployed with this address swapped in for all zkSync addresses.
+contract LimitBypassProxy is ZkSyncInterface, ZkBridgeLike {
+    using SafeERC20 for IERC20;
+    ZkSyncInterface public constant zkSync = ZkSyncInterface(0x32400084C286CF3E17e7B677ea9583e60a000324);
+    ZkBridgeLike public constant zkErc20Bridge = ZkBridgeLike(0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063);
+
+    function l2TransactionBaseCost(
+        uint256 _l1GasPrice,
+        uint256 _l2GasLimit,
+        uint256 _l2GasPerPubdataByteLimit
+    ) external view returns (uint256) {
+        return zkSync.l2TransactionBaseCost(_l1GasPrice, _l2GasLimit, _l2GasPerPubdataByteLimit);
+    }
+
+    function requestL2Transaction(
+        address _contractL2,
+        uint256 _l2Value,
+        bytes calldata _calldata,
+        uint256 _l2GasLimit,
+        uint256 _l2GasPerPubdataByteLimit,
+        bytes[] calldata _factoryDeps,
+        address _refundRecipient
+    ) external payable returns (bytes32 canonicalTxHash) {
+        return
+            zkSync.requestL2Transaction{ value: msg.value }(
+                _contractL2,
+                _l2Value,
+                _calldata,
+                _l2GasLimit,
+                _l2GasPerPubdataByteLimit,
+                _factoryDeps,
+                _refundRecipient
+            );
+    }
+
+    function deposit(
+        address _l2Receiver,
+        address _l1Token,
+        uint256 _amount,
+        uint256 _l2TxGasLimit,
+        uint256 _l2TxGasPerPubdataByte,
+        address _refundRecipient
+    ) external payable returns (bytes32 txHash) {
+        IERC20(_l1Token).safeIncreaseAllowance(address(zkErc20Bridge), _amount);
+        return
+            zkErc20Bridge.deposit{ value: msg.value }(
+                _l2Receiver,
+                _l1Token,
+                _amount,
+                _l2TxGasLimit,
+                _l2TxGasPerPubdataByte,
+                _refundRecipient
+            );
+    }
+}
+
 /**
  * @notice Contract containing logic to send messages from L1 to ZkSync.
  * @dev Public functions calling external contracts do not guard against reentrancy because they are expected to be
@@ -88,7 +145,12 @@ contract ZkSync_Adapter is AdapterInterface {
     // redeployed in the event that the following addresses change.
 
     // Main contract used to send L1 --> L2 messages. Fetchable via `zks_getMainContract` method on JSON RPC.
-    ZkSyncInterface public constant zkSync = ZkSyncInterface(0x32400084C286CF3E17e7B677ea9583e60a000324);
+    ZkSyncInterface public constant zkSyncMessageBridge = ZkSyncInterface(0x32400084C286CF3E17e7B677ea9583e60a000324);
+
+    // Contract used to send ETH to L2. Note: this is the same address as the main contract, but separated to allow
+    // only this contract to be swapped (leaving the main zkSync contract to be used for messaging).
+    ZkSyncInterface public constant zkSyncEthBridge = ZkSyncInterface(0x32400084C286CF3E17e7B677ea9583e60a000324);
+
     // Bridges to send ERC20 and ETH to L2. Fetchable via `zks_getBridgeContracts` method on JSON RPC.
     ZkBridgeLike public constant zkErc20Bridge = ZkBridgeLike(0x57891966931Eb4Bb6FB81430E6cE0A03AAbDe063);
 
@@ -117,7 +179,7 @@ contract ZkSync_Adapter is AdapterInterface {
         uint256 txBaseCost = _contractHasSufficientEthBalance();
 
         // Returns the hash of the requested L2 transaction. This hash can be used to follow the transaction status.
-        bytes32 canonicalTxHash = zkSync.requestL2Transaction{ value: txBaseCost }(
+        bytes32 canonicalTxHash = zkSyncMessageBridge.requestL2Transaction{ value: txBaseCost }(
             target,
             // We pass no ETH with the call, otherwise we'd need to add to the txBaseCost this value.
             0,
@@ -164,7 +226,7 @@ contract ZkSync_Adapter is AdapterInterface {
         if (l1Token == address(l1Weth)) {
             l1Weth.withdraw(amount);
             // We cannot call the standard ERC20 bridge because it disallows ETH deposits.
-            txHash = zkSync.requestL2Transaction{ value: txBaseCost + amount }(
+            txHash = zkSyncEthBridge.requestL2Transaction{ value: txBaseCost + amount }(
                 to,
                 amount,
                 "",
@@ -199,7 +261,8 @@ contract ZkSync_Adapter is AdapterInterface {
         // https://github.com/matter-labs/era-contracts/blob/6391c0d7bf6184d7f6718060e3991ba6f0efe4a7/ethereum/contracts/zksync/facets/Mailbox.sol#L273
         // - priority_fee_per_gas = min(transaction.max_priority_fee_per_gas, transaction.max_fee_per_gas - block.base_fee_per_gas)
         // - effective_gas_price = priority_fee_per_gas + block.base_fee_per_gas
-        return zkSync.l2TransactionBaseCost(tx.gasprice, L2_GAS_LIMIT, L1_GAS_TO_L2_GAS_PER_PUB_DATA_LIMIT);
+        return
+            zkSyncMessageBridge.l2TransactionBaseCost(tx.gasprice, L2_GAS_LIMIT, L1_GAS_TO_L2_GAS_PER_PUB_DATA_LIMIT);
     }
 
     function _contractHasSufficientEthBalance() internal view returns (uint256 requiredL1CallValue) {


### PR DESCRIPTION
This PR adds a proxy contract that could be used to bypass zk sync deposit limits by address. To allow for this proxy to be swapped out, the ETH sending address was separated from the address used to send contract calls, so one could be swapped out without affecting the other.