### PR TITLE
style: SNAKE_CASE for constants in Arbitrum_Adapter

### DIFF
--- a/contracts/chain-adapters/Arbitrum_Adapter.sol
+++ b/contracts/chain-adapters/Arbitrum_Adapter.sol
@@ -146,10 +146,10 @@ contract Arbitrum_Adapter is AdapterInterface {
     // ticket’s calldata in the retry buffer. (current base submission fee is queryable via
     // ArbRetryableTx.getSubmissionPrice). ArbRetryableTicket precompile interface exists at L2 address
     // 0x000000000000000000000000000000000000006E.
-    uint256 public constant l2MaxSubmissionCost = 0.01e18;
+    uint256 public constant L2_MAX_SUBMISSION_COST = 0.01e18;
 
     // L2 Gas price bid for immediate L2 execution attempt (queryable via standard eth*gasPrice RPC)
-    uint256 public constant l2GasPrice = 5e9; // 5 gWei
+    uint256 public constant L2_GAS_PRICE = 5e9; // 5 gWei
 
     uint32 public constant RELAY_TOKENS_L2_GAS_LIMIT = 300_000;
     uint32 public constant RELAY_MESSAGE_L2_GAS_LIMIT = 2_000_000;
@@ -184,11 +184,11 @@ contract Arbitrum_Adapter is AdapterInterface {
         l1Inbox.createRetryableTicket{ value: requiredL1CallValue }(
             target, // destAddr destination L2 contract address
             0, // l2CallValue call value for retryable L2 message
-            l2MaxSubmissionCost, // maxSubmissionCost Max gas deducted from user's L2 balance to cover base fee
+            L2_MAX_SUBMISSION_COST, // maxSubmissionCost Max gas deducted from user's L2 balance to cover base fee
             l2RefundL2Address, // excessFeeRefundAddress maxgas * gasprice - execution cost gets credited here on L2
             l2RefundL2Address, // callValueRefundAddress l2Callvalue gets credited here on L2 if retryable txn times out or gets cancelled
             RELAY_MESSAGE_L2_GAS_LIMIT, // maxGas Max gas deducted from user's L2 balance to cover L2 execution
-            l2GasPrice, // gasPriceBid price bid for L2 execution
+            L2_GAS_PRICE, // gasPriceBid price bid for L2 execution
             message // data ABI encoded data of L2 message
         );
 
@@ -219,7 +219,7 @@ contract Arbitrum_Adapter is AdapterInterface {
 
         // `outboundTransfer` expects that the caller includes a bytes message as the last param that includes the
         // maxSubmissionCost to use when creating an L2 retryable ticket: https://github.com/OffchainLabs/arbitrum/blob/e98d14873dd77513b569771f47b5e05b72402c5e/packages/arb-bridge-peripherals/contracts/tokenbridge/ethereum/gateway/L1GatewayRouter.sol#L232
-        bytes memory data = abi.encode(l2MaxSubmissionCost, "");
+        bytes memory data = abi.encode(L2_MAX_SUBMISSION_COST, "");
 
         // Note: Legacy routers don't have the outboundTransferCustomRefund method, so default to using
         // outboundTransfer(). Legacy routers are used for the following tokens that are currently enabled:
@@ -237,7 +237,7 @@ contract Arbitrum_Adapter is AdapterInterface {
                 to,
                 amount,
                 RELAY_TOKENS_L2_GAS_LIMIT,
-                l2GasPrice,
+                L2_GAS_PRICE,
                 data
             );
         } else {
@@ -247,7 +247,7 @@ contract Arbitrum_Adapter is AdapterInterface {
                 to,
                 amount,
                 RELAY_TOKENS_L2_GAS_LIMIT,
-                l2GasPrice,
+                L2_GAS_PRICE,
                 data
             );
         }
@@ -259,7 +259,7 @@ contract Arbitrum_Adapter is AdapterInterface {
      * @return amount of ETH that this contract needs to hold in order for relayMessage to succeed.
      */
     function getL1CallValue(uint32 l2GasLimit) public pure returns (uint256) {
-        return l2MaxSubmissionCost + l2GasPrice * l2GasLimit;
+        return L2_MAX_SUBMISSION_COST + L2_GAS_PRICE * l2GasLimit;
     }
 
     function _contractHasSufficientEthBalance(uint32 l2GasLimit) internal view returns (uint256 requiredL1CallValue) {


### PR DESCRIPTION
Prompted by OZ zkSync audit finding [N-01]. No functional change, but it does appease SOLHINT.