### PR TITLE
fix: SpokePool deployment script corrections

### DIFF
--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -1,11 +1,9 @@
-import { deployNewProxy } from "../utils/utils.hre";
+import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
 import { DeployFunction } from "hardhat-deploy/types";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
-  const chainId = await hre.getChainId();
-  console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);
+  const { hubPool } = await getSpokePoolDeploymentInfo(hre);
 
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -1,22 +1,20 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
-import { deployNewProxy } from "../utils/utils.hre";
+import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
-  const chainId = await hre.getChainId();
-  console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);
+  const { hubPool, spokeChainId } = await getSpokePoolDeploymentInfo(hre);
 
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const constructorArgs = [
     1_000_000,
-    L2_ADDRESS_MAP[chainId].l2GatewayRouter,
+    L2_ADDRESS_MAP[spokeChainId].l2GatewayRouter,
     hubPool.address,
     hubPool.address,
-    L2_ADDRESS_MAP[chainId].l2Weth,
+    L2_ADDRESS_MAP[spokeChainId].l2Weth,
   ];
   await deployNewProxy("Arbitrum_SpokePool", constructorArgs);
 };

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -4,9 +4,10 @@ import { L1_ADDRESS_MAP } from "./consts";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
-  const chainId = await hre.getChainId();
-  console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);
+  const { deployments, getChainId } = hre;
+  const chainId = await getChainId();
+  const hubPool = await deployments.get("HubPool");
+  console.log(`Using chain ${chainId} HubPool @ ${hubPool.address}`);
 
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -1,12 +1,10 @@
 import { DeployFunction } from "hardhat-deploy/types";
 import { L2_ADDRESS_MAP } from "./consts";
-import { deployNewProxy } from "../utils/utils.hre";
+import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
-  const chainId = await hre.getChainId();
-  console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);
+  const { hubPool, spokeChainId } = await getSpokePoolDeploymentInfo(hre);
 
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.
@@ -18,8 +16,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     "0x0330E9b4D0325cCfF515E81DFbc7754F2a02ac57",
     hubPool.address,
     hubPool.address,
-    L2_ADDRESS_MAP[chainId].wMatic,
-    L2_ADDRESS_MAP[chainId].fxChild,
+    L2_ADDRESS_MAP[spokeChainId].wMatic,
+    L2_ADDRESS_MAP[spokeChainId].fxChild,
   ];
   await deployNewProxy("Polygon_SpokePool", constructorArgs);
 };

--- a/deploy/013_deploy_boba_spokepool.ts
+++ b/deploy/013_deploy_boba_spokepool.ts
@@ -1,11 +1,9 @@
 import { DeployFunction } from "hardhat-deploy/types";
-import { deployNewProxy } from "../utils/utils.hre";
+import { deployNewProxy, getSpokePoolDeploymentInfo } from "../utils/utils.hre";
 import { HardhatRuntimeEnvironment } from "hardhat/types";
 
 const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
-  const hubPool = await hre.companionNetworks.l1.deployments.get("HubPool");
-  const chainId = await hre.getChainId();
-  console.log(`Using L1 (chainId ${chainId}) hub pool @ ${hubPool.address}`);
+  const { hubPool } = await getSpokePoolDeploymentInfo(hre);
 
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -139,7 +139,6 @@ const config: HardhatUserConfig = {
       accounts: { mnemonic },
       saveDeployments: true,
       chainId: 11155111,
-      companionNetworks: { l1: "sepolia" },
     },
     polygon: {
       chainId: 137,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -62,6 +62,7 @@ const config: HardhatUserConfig = {
       accounts: { mnemonic },
       saveDeployments: true,
       chainId: 1,
+      companionNetworks: { l1: "mainnet" },
     },
     "zksync-goerli": {
       chainId: 280,
@@ -133,12 +134,14 @@ const config: HardhatUserConfig = {
       url: getNodeUrl("goerli", true, 5),
       saveDeployments: true,
       accounts: { mnemonic },
+      companionNetworks: { l1: "goerli" },
     },
     sepolia: {
       url: "https://rpc2.sepolia.org",
       accounts: { mnemonic },
       saveDeployments: true,
       chainId: 11155111,
+      companionNetworks: { l1: "sepolia" },
     },
     polygon: {
       chainId: 137,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -62,7 +62,6 @@ const config: HardhatUserConfig = {
       accounts: { mnemonic },
       saveDeployments: true,
       chainId: 1,
-      companionNetworks: { l1: "mainnet" },
     },
     "zksync-goerli": {
       chainId: 280,
@@ -134,7 +133,6 @@ const config: HardhatUserConfig = {
       url: getNodeUrl("goerli", true, 5),
       saveDeployments: true,
       accounts: { mnemonic },
-      companionNetworks: { l1: "goerli" },
     },
     sepolia: {
       url: "https://rpc2.sepolia.org",

--- a/utils/utils.hre.ts
+++ b/utils/utils.hre.ts
@@ -3,6 +3,12 @@ import { HardhatRuntimeEnvironment } from "hardhat/types";
 import { Deployment } from "hardhat-deploy/types";
 import { getContractFactory } from "./utils";
 
+/**
+ * @description Resolve the HubPool deployment, as well as the HubPool and SpokePool chain IDs for a new deployment.
+ * @dev This function relies on having companionNetworks defined in the HardhatUserConfig.
+ * @dev This should only be used when deploying a SpokePool to a satellite chain (i.e. HubChainId != SpokeChainId).
+ * @returns HubPool instance, HubPool chain ID and SpokePool chain ID.
+ */
 export async function getSpokePoolDeploymentInfo(
   hre: HardhatRuntimeEnvironment
 ): Promise<{ hubPool: Deployment; hubChainId: number; spokeChainId: number }> {

--- a/utils/utils.hre.ts
+++ b/utils/utils.hre.ts
@@ -14,6 +14,7 @@ export async function getSpokePoolDeploymentInfo(
 ): Promise<{ hubPool: Deployment; hubChainId: number; spokeChainId: number }> {
   const { companionNetworks, getChainId } = hre;
   const spokeChainId = Number(await getChainId());
+
   const hubChain = companionNetworks.l1;
   const hubPool = await hubChain.deployments.get("HubPool");
   const hubChainId = Number(await hubChain.getChainId());

--- a/utils/utils.hre.ts
+++ b/utils/utils.hre.ts
@@ -1,5 +1,20 @@
-import { getContractFactory } from "./utils";
 import hre from "hardhat";
+import { HardhatRuntimeEnvironment } from "hardhat/types";
+import { Deployment } from "hardhat-deploy/types";
+import { getContractFactory } from "./utils";
+
+export async function getSpokePoolDeploymentInfo(
+  hre: HardhatRuntimeEnvironment
+): Promise<{ hubPool: Deployment; hubChainId: number; spokeChainId: number }> {
+  const { companionNetworks, getChainId } = hre;
+  const spokeChainId = Number(await getChainId());
+  const hubChain = companionNetworks.l1;
+  const hubPool = await hubChain.deployments.get("HubPool");
+  const hubChainId = Number(await hubChain.getChainId());
+  console.log(`Using chain ${hubChainId} HubPool @ ${hubPool.address}`);
+
+  return { hubPool, hubChainId, spokeChainId };
+}
 
 export async function deployNewProxy(name: string, args: (number | string)[]): Promise<void> {
   const { run, upgrades } = hre;


### PR DESCRIPTION
The Ethereum SpokePool deployment script relies on companionNetworks being defined in order to resolve the HubPool and WETH contract addresses. This does unfortunately create a circular reference, but it permits deployment and I haven't seen any negative side-effects.

Additionally, the other SpokePool deployment scripts incorrectly logged the chain ID for the HubPool deployment. This change now factors out the task of resolving the chain IDs and returns them in an unambiguous form. This also simplifies most of the deployment scripts.