### PR TITLE
fix(SpokePool): SlowFill should still transfer if executed by recipient

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1213,7 +1213,9 @@ abstract contract SpokePool is
         // net movement of funds.
         // Note: this is important because it means that relayers can intentionally self-relay in a capital efficient
         // way (no need to have funds on the destination).
-        if (msg.sender == relayExecution.updatedRecipient) return fillAmountPreFees;
+        // If this is a slow fill, we can't exit early since we still need to send funds out of this contract
+        // since there is no "relayer".
+        if (msg.sender == relayExecution.updatedRecipient && !relayExecution.slowFill) return fillAmountPreFees;
 
         // If relay token is wrappedNativeToken then unwrap and send native token.
         if (relayData.destinationToken == address(wrappedNativeToken)) {

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -176,6 +176,32 @@ describe("SpokePool Slow Relay Logic", async function () {
       [fullRelayAmountPostFees.mul(10).mul(-1), fullRelayAmountPostFees.mul(10)]
     );
   });
+  it("Recipient should be able to execute their own slow relay", async function () {
+    await expect(() =>
+      spokePool
+        .connect(recipient)
+        .executeSlowRelayLeaf(
+          ...getExecuteSlowRelayParams(
+            depositor.address,
+            recipient.address,
+            destErc20.address,
+            consts.amountToRelay,
+            consts.originChainId,
+            consts.realizedLpFeePct,
+            consts.depositRelayerFeePct,
+            consts.firstDepositId,
+            0,
+            erc20Message,
+            ethers.utils.parseEther("9"),
+            tree.getHexProof(slowFills.find((slowFill) => slowFill.relayData.destinationToken === destErc20.address)!)
+          )
+        )
+    ).to.changeTokenBalances(
+      destErc20,
+      [spokePool, recipient],
+      [fullRelayAmountPostFees.mul(10).mul(-1), fullRelayAmountPostFees.mul(10)]
+    );
+  });
 
   it("Simple SlowRelay ERC20 FilledRelay event", async function () {
     slowFills.find((slowFill) => slowFill.relayData.destinationToken === destErc20.address)!;


### PR DESCRIPTION
SlowFill reuses existing _fillRelay logic to fill a slow relay leaf. This function has an early return path where if the msg.sender == recipient, it will exit early to avoid a transfer. This is useful for a 
normal relay where a relayer, relaying to themselves, shouldn't need to send funds to itself. However, for a slow fill, the "relayer" is the contract (i.e. funds are sent out out of the spoke pool rather 
than brought in by the relayer/msg.sender) so we always want to send funds if we're in a slow relay.

Signed-off-by: nicholaspai <npai.nyc@gmail.com>

Fixes ACX-1394
