### PR TITLE
fix: BondToken license

### DIFF
--- a/contracts/BondToken.sol
+++ b/contracts/BondToken.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: BUSL-1.1
+// SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/access/Ownable.sol";


### PR DESCRIPTION
The BondToken contract is basically WETH9, so we inherit its license.