### PR TITLE
refactor: Split out and improve SpokePool deposit tests

### DIFF
--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -62,8 +62,8 @@ export async function enableRoutes(spokePool: Contract, routes: DepositRoute[]) 
   for (const route of routes) {
     await spokePool.setEnableRoute(
       route.originToken,
-      route.destinationChainId ? route.destinationChainId : consts.destinationChainId,
-      route.enabled !== undefined ? route.enabled : true
+      route.destinationChainId ?? consts.destinationChainId,
+      route.enabled ?? true
     );
   }
 }


### PR DESCRIPTION
There are many now, so it makes sense to split them apart before adding new ones. While here:

 - Enforce that deposits revert for the expected revert reasons.
 - Enforce that deposits succeed and emit a "FundsDeposited" event.
 - Tweak a utility function for simplicity.

Done in advance of a proposed change to the SpokePool quoteTimestamp validation.