### PR TITLE
feat: deposit() wrapper with current quoteTimestamp

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -481,6 +481,42 @@ abstract contract SpokePool is
     }
 
     /**
+     * @notice This is a simple wrapper for deposit() that sets the quoteTimestamp to the current SpokePool timestamp.
+     * @notice This function is intended for multisig depositors who can accept some LP fee uncertainty in order to lift
+     * the quoteTimestamp buffer constraint.
+     * @dev Re-orgs may produce invalid fills if the quoteTimestamp moves across a change in HubPool utilisation.
+     * @dev The existing function modifiers are already enforced by deposit(), so no additional modifiers are imposed.
+     * @param recipient Address to receive funds at on destination chain.
+     * @param originToken Token to lock into this contract to initiate deposit.
+     * @param amount Amount of tokens to deposit. Will be amount of tokens to receive less fees.
+     * @param destinationChainId Denotes network where user will receive funds from SpokePool by a relayer.
+     * @param relayerFeePct % of deposit amount taken out to incentivize a fast relayer.
+     * @param message Arbitrary data that can be used to pass additional information to the recipient along with the tokens.
+     * Note: this is intended to be used to pass along instructions for how a contract should use or allocate the tokens.
+     * @param maxCount used to protect the depositor from frontrunning to guarantee their quote remains valid.
+     */
+    function depositNow(
+        address recipient,
+        address originToken,
+        uint256 amount,
+        uint256 destinationChainId,
+        int64 relayerFeePct,
+        bytes memory message,
+        uint256 maxCount
+    ) public payable {
+        deposit(
+            recipient,
+            originToken,
+            amount,
+            destinationChainId,
+            relayerFeePct,
+            uint32(getCurrentTime()),
+            message,
+            maxCount
+        );
+    }
+
+    /**
      * @notice Convenience method that depositor can use to signal to relayer to use updated fee.
      * @notice Relayer should only use events emitted by this function to submit fills with updated fees, otherwise they
      * risk their fills getting disputed for being invalid, for example if the depositor never actually signed the

--- a/contracts/interfaces/SpokePoolInterface.sol
+++ b/contracts/interfaces/SpokePoolInterface.sol
@@ -98,6 +98,16 @@ interface SpokePoolInterface {
         uint256 maxCount
     ) external payable;
 
+    function depositNow(
+        address recipient,
+        address originToken,
+        uint256 amount,
+        uint256 destinationChainId,
+        int64 relayerFeePct,
+        bytes memory message,
+        uint256 maxCount
+    ) external payable;
+
     function speedUpDeposit(
         address depositor,
         int64 updatedRelayerFeePct,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -44,6 +44,7 @@ const config: HardhatUserConfig = {
       "contracts/Boba_SpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       "contracts/Optimism_SpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       "contracts/Base_SpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+      "contracts/Polygon_SpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       "contracts/test/MockSpokePoolV2.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       "contracts/test/MockOptimism_SpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
     },

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -342,6 +342,7 @@ describe("SpokePool Depositor Logic", async function () {
   });
 
   it("quoteTimestamp is set correctly by depositNow()", async function () {
+    // ERC20 deposit
     await expect(
       spokePool
         .connect(depositor)
@@ -368,6 +369,38 @@ describe("SpokePool Depositor Logic", async function () {
         depositor.address,
         "0x"
       );
+
+    // Native token deposit - amount != msg.value
+    await expect(
+      spokePool
+        .connect(depositor)
+        .depositNow(
+          recipient.address,
+          weth.address,
+          amountToDeposit.toString(),
+          destinationChainId.toString(),
+          depositRelayerFeePct.toString(),
+          "0x",
+          maxUint256,
+          { value: amountToDeposit.add(1) }
+        )
+    ).to.be.revertedWith("msg.value must match amount");
+
+    // Native token deposit - amount == msg.value.
+    await expect(() =>
+      spokePool
+        .connect(depositor)
+        .depositNow(
+          recipient.address,
+          weth.address,
+          amountToDeposit.toString(),
+          destinationChainId.toString(),
+          depositRelayerFeePct.toString(),
+          "0x",
+          maxUint256,
+          { value: amountToDeposit }
+        )
+    ).to.changeEtherBalances([depositor, weth], [amountToDeposit.mul(toBN("-1")), amountToDeposit]);
   });
 
   it("maxCount is too low", async function () {

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -341,6 +341,35 @@ describe("SpokePool Depositor Logic", async function () {
     ).to.emit(spokePool, "FundsDeposited");
   });
 
+  it("quoteTimestamp is set correctly by depositNow()", async function () {
+    await expect(
+      spokePool
+        .connect(depositor)
+        .depositNow(
+          recipient.address,
+          erc20.address,
+          amountToDeposit.toString(),
+          destinationChainId.toString(),
+          depositRelayerFeePct.toString(),
+          "0x",
+          maxUint256
+        )
+    )
+      .to.emit(spokePool, "FundsDeposited")
+      .withArgs(
+        amountToDeposit,
+        destinationChainId,
+        destinationChainId,
+        depositRelayerFeePct,
+        0,
+        currentSpokePoolTime,
+        erc20.address,
+        recipient.address,
+        depositor.address,
+        "0x"
+      );
+  });
+
   it("maxCount is too low", async function () {
     const revertReason = "Above max count";
 


### PR DESCRIPTION
depositNow() is a new deposit() wrapper that removes the need for the caller to supply a quoteTimestamp. Instead, the value of getCurrentTime() is used.

This is introduced to address the issue of multisig depositors having only a narrow window to collect the necessary signatures for a deposit. Instead, LP fee certainty is traded for flexibility around when the deposit is able to be submitted. The depositor is still able to query the expected LP fee via the Across API, so the chance of paying more fees than anticipated is fairly low.

Ref ACX-1544