### PR TITLE
chore(across-v2): Bump patch level

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.4.5",
+  "version": "2.4.6",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
Release v2.4.5 was never actually produced, but tag v2.4.5 was accidentally used when producing a draft release.