### PR TITLE
feat(SpokePool): Modify existing deposit() function to emit USSFundsDeposited event and add new depositUSS function

### DIFF
--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -10,7 +10,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
  */
 contract MockSpokePool is SpokePool, OwnableUpgradeable {
     uint256 private chainId_;
-    uint256 private currentTime;
+    uint32 private currentTime;
 
     function initialize(
         uint32 _initialDepositId,
@@ -20,14 +20,14 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
     ) public initializer {
         __Ownable_init();
         __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, _wethAddress);
-        currentTime = block.timestamp; // solhint-disable-line not-rely-on-time
+        currentTime = uint32(block.timestamp); // solhint-disable-line not-rely-on-time
     }
 
-    function setCurrentTime(uint256 time) external {
+    function setCurrentTime(uint32 time) external {
         currentTime = time;
     }
 
-    function getCurrentTime() public view override returns (uint256) {
+    function getCurrentTime() public view override returns (uint32) {
         return currentTime;
     }
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -38,7 +38,7 @@ const LARGE_CONTRACT_COMPILER_SETTINGS = {
 
 const XTRA_LARGE_CONTRACT_COMPILER_SETTINGS = {
   version: solcVersion,
-  settings: { optimizer: { enabled: true, runs: 200 }, viaIR: true },
+  settings: { optimizer: { enabled: true, runs: 100 }, viaIR: true },
 };
 
 const config: HardhatUserConfig = {

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -1,11 +1,24 @@
-import { expect, ethers, Contract, SignerWithAddress, seedWallet, toBN, toWei, randomAddress } from "../utils/utils";
+import {
+  expect,
+  ethers,
+  Contract,
+  SignerWithAddress,
+  seedWallet,
+  toBN,
+  toWei,
+  randomAddress,
+  BigNumber,
+} from "../utils/utils";
 import { spokePoolFixture, enableRoutes, getDepositParams } from "./fixtures/SpokePool.Fixture";
 import {
   amountToSeedWallets,
   amountToDeposit,
   destinationChainId,
-  depositRelayerFeePct as relayerFeePct,
+  depositRelayerFeePct,
+  realizedLpFeePct,
+  amountReceived,
   maxUint256,
+  MAX_UINT32,
 } from "./constants";
 
 const { AddressZero: ZERO_ADDRESS } = ethers.constants;
@@ -17,6 +30,7 @@ describe("SpokePool Depositor Logic", async function () {
   let depositor: SignerWithAddress, recipient: SignerWithAddress;
   let quoteTimestamp: number;
   let amount = amountToDeposit;
+  const relayerFeePct = toBN(depositRelayerFeePct).add(realizedLpFeePct);
 
   beforeEach(async function () {
     [depositor, recipient] = await ethers.getSigners();
@@ -32,7 +46,7 @@ describe("SpokePool Depositor Logic", async function () {
     // Whitelist origin token => destination chain ID routes:
     await enableRoutes(spokePool, [{ originToken: erc20.address }, { originToken: weth.address }]);
 
-    quoteTimestamp = (await spokePool.getCurrentTime()).toNumber();
+    quoteTimestamp = await spokePool.getCurrentTime();
   });
 
   it("Depositing ERC20 tokens correctly pulls tokens and changes contract state", async function () {
@@ -66,17 +80,17 @@ describe("SpokePool Depositor Logic", async function () {
         })
       )
     )
-      .to.emit(spokePool, "FundsDeposited")
+      .to.emit(spokePool, "USSFundsDeposited")
       .withArgs(
-        amountToDeposit,
+        [erc20.address, amountToDeposit],
+        [ZERO_ADDRESS, amountReceived],
         destinationChainId,
-        destinationChainId,
-        relayerFeePct,
         0,
         quoteTimestamp,
-        erc20.address,
-        recipient.address,
+        MAX_UINT32,
         depositor.address,
+        recipient.address,
+        ZERO_ADDRESS,
         "0x"
       );
 
@@ -106,17 +120,17 @@ describe("SpokePool Depositor Logic", async function () {
         })
       )
     )
-      .to.emit(spokePool, "FundsDeposited")
+      .to.emit(spokePool, "USSFundsDeposited")
       .withArgs(
-        amountToDeposit,
+        [erc20.address, amountToDeposit],
+        [ZERO_ADDRESS, amountReceived],
         destinationChainId,
-        destinationChainId,
-        relayerFeePct,
         0,
         quoteTimestamp,
-        erc20.address,
+        BigNumber.from("0xFFFFFFFF"),
+        newDepositor, // Depositor is overridden.
         recipient.address,
-        newDepositor, // This gets overridden
+        ZERO_ADDRESS,
         "0x"
       );
   });
@@ -198,7 +212,7 @@ describe("SpokePool Depositor Logic", async function () {
           quoteTimestamp,
         })
       )
-    ).to.emit(spokePool, "FundsDeposited");
+    ).to.emit(spokePool, "USSFundsDeposited");
   });
 
   it("Deposit route is disabled", async function () {
@@ -228,7 +242,7 @@ describe("SpokePool Depositor Logic", async function () {
           quoteTimestamp,
         })
       )
-    ).to.emit(spokePool, "FundsDeposited");
+    ).to.emit(spokePool, "USSFundsDeposited");
 
     // Disable the route.
     await spokePool.connect(depositor).setEnableRoute(erc20.address, destinationChainId, false);
@@ -257,7 +271,7 @@ describe("SpokePool Depositor Logic", async function () {
           quoteTimestamp,
         })
       )
-    ).to.emit(spokePool, "FundsDeposited");
+    ).to.emit(spokePool, "USSFundsDeposited");
   });
 
   it("Relayer fee is invalid", async function () {
@@ -317,7 +331,7 @@ describe("SpokePool Depositor Logic", async function () {
             quoteTimestamp: quoteTimestamp - offset,
           })
         )
-      ).to.emit(spokePool, "FundsDeposited");
+      ).to.emit(spokePool, "USSFundsDeposited");
     }
   });
 
@@ -336,17 +350,17 @@ describe("SpokePool Depositor Logic", async function () {
           maxUint256
         )
     )
-      .to.emit(spokePool, "FundsDeposited")
+      .to.emit(spokePool, "USSFundsDeposited")
       .withArgs(
-        amountToDeposit,
+        [erc20.address, amountToDeposit],
+        [ZERO_ADDRESS, amountReceived],
         destinationChainId,
-        destinationChainId,
-        relayerFeePct,
         0,
         quoteTimestamp,
-        erc20.address,
-        recipient.address,
+        BigNumber.from("0xFFFFFFFF"),
         depositor.address,
+        recipient.address,
+        ZERO_ADDRESS,
         "0x"
       );
 
@@ -398,7 +412,7 @@ describe("SpokePool Depositor Logic", async function () {
           maxCount,
         })
       )
-    ).to.emit(spokePool, "FundsDeposited");
+    ).to.emit(spokePool, "USSFundsDeposited");
 
     await expect(
       spokePool.connect(depositor).deposit(

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -492,7 +492,7 @@ describe("SpokePool Relayer Logic", async function () {
   });
   describe("fill USS", function () {
     it("placeholder: gas test", async function () {
-      const fillDeadline = (await spokePool.getCurrentTime()).toNumber() + 1000;
+      const fillDeadline = Number(await spokePool.getCurrentTime()) + 1000;
 
       await spokePool.fillRelayUSS(
         depositor.address,

--- a/test/constants.ts
+++ b/test/constants.ts
@@ -1,6 +1,6 @@
 import { toWei, utf8ToHex, toBN, createRandomBytes32 } from "../utils/utils";
 
-import { ethers } from "ethers";
+import { BigNumber, ethers } from "ethers";
 
 export { TokenRolesEnum } from "@uma/common";
 
@@ -29,6 +29,8 @@ export const totalPostFeesPct = toBN(oneHundredPct).sub(toBN(depositRelayerFeePc
 export const totalPostModifiedFeesPct = toBN(oneHundredPct).sub(toBN(modifiedRelayerFeePct).add(realizedLpFeePct));
 
 export const amountToRelayPreFees = toBN(amountToRelay).mul(toBN(oneHundredPct)).div(totalPostFeesPct);
+
+export const amountReceived = toBN(amountToDeposit).mul(toBN(totalPostFeesPct)).div(toBN(oneHundredPct));
 
 export const amountToRelayPreModifiedFees = toBN(amountToRelay).mul(toBN(oneHundredPct)).div(totalPostModifiedFeesPct);
 
@@ -97,6 +99,8 @@ export const maxL1TokensPerPoolRebalanceLeaf = 3;
 // Once running balances hits this number for an L1 token, net send amount should be set to running
 // balances to transfer tokens to the spoke pool.
 export const l1TokenTransferThreshold = toWei(100);
+
+export const MAX_UINT32 = BigNumber.from("0xFFFFFFFF");
 
 // DAI's Rate model.
 export const sampleRateModel = {


### PR DESCRIPTION
Fixes #ACX-1684 and #ACX-1685

## Modifications to existing deposit function: deposit():
- At upgrade: backwards compatible deposit() function will emit the new event. The deposit2() function (with new params) will emit the new event as well. There will be no deposit function post upgrade that emits the old event. The idea behind modifying the existing function is that post-upgrade, no more “old deposits” are emitted.
- Instead of the depositor using the relayerFeePct parameter to set the relayer’s portion of the fee, depositor uses the relayerFeePct to mark a “total fee” percentage. The recipient therefore knows that they will receive `amount * (1 - relayerFeePct)` tokens. The funds deposited event emits outputTokenAmount equal to this amount * (1 - relayerFeePct).
- outputToken: new parameter, defaults to some default token address like 0x0 to indicate that the same input and output token should be used
- Should hardcode committedFiller to 0x0
- Set expiryTimestamp to MAX_UINT. We never want to process deposit refunds for “old deposits”. We should add a rule in the dataworker that deposit refunds only count for type 2 deposits.

## Provides new public function deposit2() for depositors:
- expiryTimestamp: integer - This is going to be relative to the destination chain. Don’t allow this to be more than ~3 bundles into the future, so 12 hours maybe. This way the dataworker/relayer doesn’t have to maintain more a lookback longer than this.
- Emits FundsDeposited2 event