### PR TITLE
improve(SpokePool): Convert wrappedNativeToken from variable to overridable public function

### DIFF
--- a/contracts/Arbitrum_SpokePool.sol
+++ b/contracts/Arbitrum_SpokePool.sol
@@ -34,22 +34,24 @@ contract Arbitrum_SpokePool is SpokePool {
      * @param _l2GatewayRouter Address of L2 token gateway. Can be reset by admin.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
      * @param _hubPool Hub pool address to set. Can be changed by admin.
-     * @param _wethAddress Weth address for this network to set.
      */
     function initialize(
         uint32 _initialDepositId,
         address _l2GatewayRouter,
         address _crossDomainAdmin,
-        address _hubPool,
-        address _wethAddress
+        address _hubPool
     ) public initializer {
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, _wethAddress);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
         _setL2GatewayRouter(_l2GatewayRouter);
     }
 
     modifier onlyFromCrossDomainAdmin() {
         require(msg.sender == _applyL1ToL2Alias(crossDomainAdmin), "ONLY_COUNTERPART_GATEWAY");
         _;
+    }
+
+    function wrappedNativeToken() public pure override returns (WETH9Interface) {
+        return WETH9Interface(0x82aF49447D8a07e3bd95BD0d56f35241523fBab1);
     }
 
     /********************************************************

--- a/contracts/Base_SpokePool.sol
+++ b/contracts/Base_SpokePool.sol
@@ -20,12 +20,10 @@ contract Base_SpokePool is Ovm_SpokePool {
         address _crossDomainAdmin,
         address _hubPool
     ) public initializer {
-        __OvmSpokePool_init(
-            _initialDepositId,
-            _crossDomainAdmin,
-            _hubPool,
-            Lib_PredeployAddresses.OVM_ETH,
-            0x4200000000000000000000000000000000000006
-        );
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+    }
+
+    function wrappedNativeToken() public pure override returns (WETH9Interface) {
+        return WETH9Interface(0x4200000000000000000000000000000000000006);
     }
 }

--- a/contracts/Boba_SpokePool.sol
+++ b/contracts/Boba_SpokePool.sol
@@ -19,12 +19,10 @@ contract Boba_SpokePool is Ovm_SpokePool {
         address _crossDomainAdmin,
         address _hubPool
     ) public initializer {
-        __OvmSpokePool_init(
-            _initialDepositId,
-            _crossDomainAdmin,
-            _hubPool,
-            0x4200000000000000000000000000000000000006,
-            0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000
-        );
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, 0x4200000000000000000000000000000000000006);
+    }
+
+    function wrappedNativeToken() public pure override returns (WETH9Interface) {
+        return WETH9Interface(0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000);
     }
 }

--- a/contracts/Ethereum_SpokePool.sol
+++ b/contracts/Ethereum_SpokePool.sol
@@ -16,15 +16,14 @@ contract Ethereum_SpokePool is SpokePool, OwnableUpgradeable {
      * @param _initialDepositId Starting deposit ID. Set to 0 unless this is a re-deployment in order to mitigate
      * relay hash collisions.
      * @param _hubPool Hub pool address to set. Can be changed by admin.
-     * @param _wethAddress Weth address for this network to set.
      */
-    function initialize(
-        uint32 _initialDepositId,
-        address _hubPool,
-        address _wethAddress
-    ) public initializer {
+    function initialize(uint32 _initialDepositId, address _hubPool) public initializer {
         __Ownable_init();
-        __SpokePool_init(_initialDepositId, _hubPool, _hubPool, _wethAddress);
+        __SpokePool_init(_initialDepositId, _hubPool, _hubPool);
+    }
+
+    function wrappedNativeToken() public pure override returns (WETH9Interface) {
+        return WETH9Interface(0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2);
     }
 
     /**************************************

--- a/contracts/Optimism_SpokePool.sol
+++ b/contracts/Optimism_SpokePool.sol
@@ -20,12 +20,10 @@ contract Optimism_SpokePool is Ovm_SpokePool {
         address _crossDomainAdmin,
         address _hubPool
     ) public initializer {
-        __OvmSpokePool_init(
-            _initialDepositId,
-            _crossDomainAdmin,
-            _hubPool,
-            Lib_PredeployAddresses.OVM_ETH,
-            0x4200000000000000000000000000000000000006
-        );
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, Lib_PredeployAddresses.OVM_ETH);
+    }
+
+    function wrappedNativeToken() public pure override returns (WETH9Interface) {
+        return WETH9Interface(0x4200000000000000000000000000000000000006);
     }
 }

--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -77,7 +77,6 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
      * @param _polygonTokenBridger Token routing contract that sends tokens from here to HubPool. Changeable by Admin.
      * @param _crossDomainAdmin Cross domain admin to set. Can be changed by admin.
      * @param _hubPool Hub pool address to set. Can be changed by admin.
-     * @param _wmaticAddress Replaces wrappedNativeToken for this network since MATIC is the native currency on polygon.
      * @param _fxChild FxChild contract, changeable by Admin.
      */
     function initialize(
@@ -85,14 +84,18 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
         PolygonTokenBridger _polygonTokenBridger,
         address _crossDomainAdmin,
         address _hubPool,
-        address _wmaticAddress, // Note: wmatic is used here since it is the token sent via msg.value on polygon.
         address _fxChild
     ) public initializer {
         callValidated = false;
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, _wmaticAddress);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
         polygonTokenBridger = _polygonTokenBridger;
         //slither-disable-next-line missing-zero-check
         fxChild = _fxChild;
+    }
+
+    function wrappedNativeToken() public pure override returns (WETH9Interface) {
+        // wmatic address.
+        return WETH9Interface(0x7ceB23fD6bC0adD59E62ac25578270cFf1b9f619);
     }
 
     /********************************************************
@@ -250,7 +253,7 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
     function _wrap() internal {
         uint256 balance = address(this).balance;
         //slither-disable-next-line arbitrary-send-eth
-        if (balance > 0) wrappedNativeToken.deposit{ value: balance }();
+        if (balance > 0) wrappedNativeToken().deposit{ value: balance }();
     }
 
     // @dev: This contract will trigger admin functions internally via the `processMessageFromRoot`, which is why

--- a/contracts/Succinct_SpokePool.sol
+++ b/contracts/Succinct_SpokePool.sol
@@ -18,6 +18,8 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
     // private. Leaving it set to true can permanently disable admin calls.
     bool private adminCallValidated;
 
+    WETH9Interface public _wrappedNativeTokenAddress;
+
     event SetSuccinctTargetAmb(address indexed newSuccinctTargetAmb);
     event ReceivedMessageFromL1(address indexed caller, address indexed rootMessageSender);
 
@@ -59,9 +61,14 @@ contract Succinct_SpokePool is SpokePool, ITelepathyHandler {
         address _hubPool,
         address _wrappedNativeToken
     ) public initializer {
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, _wrappedNativeToken);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
         succinctTargetAmb = _succinctTargetAmb;
         hubChainId = _hubChainId;
+        _wrappedNativeTokenAddress = WETH9Interface(_wrappedNativeToken);
+    }
+
+    function wrappedNativeToken() public view override returns (WETH9Interface) {
+        return _wrappedNativeTokenAddress;
     }
 
     /**

--- a/contracts/test/MockOptimism_SpokePool.sol
+++ b/contracts/test/MockOptimism_SpokePool.sol
@@ -6,13 +6,20 @@ import "../Ovm_SpokePool.sol";
  * @notice Mock Optimism Spoke pool allowing deployer to override constructor params.
  */
 contract MockOptimism_SpokePool is Ovm_SpokePool {
+    address private wethAddress;
+
     function initialize(
-        address l2Weth,
         address l2Eth,
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool
+        address _hubPool,
+        address _wethAddress
     ) public initializer {
-        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, l2Eth, l2Weth);
+        __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, l2Eth);
+        wethAddress = _wethAddress;
+    }
+
+    function wrappedNativeToken() public view override returns (WETH9Interface) {
+        return WETH9Interface(wethAddress);
     }
 }

--- a/contracts/test/MockOptimism_SpokePool.sol
+++ b/contracts/test/MockOptimism_SpokePool.sol
@@ -9,14 +9,14 @@ contract MockOptimism_SpokePool is Ovm_SpokePool {
     address private wethAddress;
 
     function initialize(
+        address _l2WethAddress,
         address l2Eth,
         uint32 _initialDepositId,
         address _crossDomainAdmin,
-        address _hubPool,
-        address _wethAddress
+        address _hubPool
     ) public initializer {
         __OvmSpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, l2Eth);
-        wethAddress = _wethAddress;
+        wethAddress = _l2WethAddress;
     }
 
     function wrappedNativeToken() public view override returns (WETH9Interface) {

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 contract MockSpokePool is SpokePool, OwnableUpgradeable {
     uint256 private chainId_;
     uint256 private currentTime;
+    address private wethAddress;
 
     function initialize(
         uint32 _initialDepositId,
@@ -19,8 +20,13 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
         address _wethAddress
     ) public initializer {
         __Ownable_init();
-        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool, _wethAddress);
+        __SpokePool_init(_initialDepositId, _crossDomainAdmin, _hubPool);
         currentTime = block.timestamp; // solhint-disable-line not-rely-on-time
+        wethAddress = _wethAddress;
+    }
+
+    function wrappedNativeToken() public view override returns (WETH9Interface) {
+        return WETH9Interface(wethAddress);
     }
 
     function setCurrentTime(uint256 time) external {

--- a/contracts/test/MockZkSync_SpokePool.sol
+++ b/contracts/test/MockZkSync_SpokePool.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+import "../ZkSync_SpokePool.sol";
+
+/**
+ * @notice Mock ZkSync Spoke pool allowing deployer to test internal functions.
+ */
+contract MockZkSync_SpokePool is ZkSync_SpokePool {
+    function bridgeTokensToHubPool(RelayerRefundLeaf memory relayerRefundLeaf) public {
+        _bridgeTokensToHubPool(relayerRefundLeaf);
+    }
+}

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -9,13 +9,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
-  const constructorArgs = [
-    1_000_000,
-    L2_ADDRESS_MAP[spokeChainId].l2GatewayRouter,
-    hubPool.address,
-    hubPool.address,
-    L2_ADDRESS_MAP[spokeChainId].l2Weth,
-  ];
+  const constructorArgs = [1_000_000, L2_ADDRESS_MAP[spokeChainId].l2GatewayRouter, hubPool.address, hubPool.address];
   await deployNewProxy("Arbitrum_SpokePool", constructorArgs);
 };
 module.exports = func;

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -22,7 +22,6 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     L2_ADDRESS_MAP[spokeChainId].zkErc20Bridge,
     hubPool.address,
     hubPool.address,
-    L2_ADDRESS_MAP[spokeChainId].l2Weth,
   ];
 
   const proxy = await zkUpgrades.deployProxy(deployer.zkWallet, artifact, initArgs, {

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -56,6 +56,7 @@ const config: HardhatUserConfig = {
       "contracts/Polygon_SpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       "contracts/test/MockSpokePoolV2.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       "contracts/test/MockSpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
+      "contracts/test/MockZkSync_SpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       "contracts/test/MockOptimism_SpokePool.sol": LARGE_CONTRACT_COMPILER_SETTINGS,
       "contracts/Ovm_SpokePool.sol": XTRA_LARGE_CONTRACT_COMPILER_SETTINGS,
     },

--- a/test/chain-specific-spokepools/Arbitrum_SpokePool.ts
+++ b/test/chain-specific-spokepools/Arbitrum_SpokePool.ts
@@ -16,7 +16,7 @@ import { hubPoolFixture } from "../fixtures/HubPool.Fixture";
 import { constructSingleRelayerRefundTree } from "../MerkleLib.utils";
 
 let hubPool: Contract, arbitrumSpokePool: Contract, dai: Contract, weth: Contract;
-let l2Weth: string, l2Dai: string, crossDomainAliasAddress;
+let l2Dai: string, crossDomainAliasAddress;
 
 let owner: SignerWithAddress, relayer: SignerWithAddress, rando: SignerWithAddress, crossDomainAlias: SignerWithAddress;
 let l2GatewayRouter: FakeContract;
@@ -24,7 +24,7 @@ let l2GatewayRouter: FakeContract;
 describe("Arbitrum Spoke Pool", function () {
   beforeEach(async function () {
     [owner, relayer, rando] = await ethers.getSigners();
-    ({ weth, l2Weth, dai, l2Dai, hubPool } = await hubPoolFixture());
+    ({ weth, dai, l2Dai, hubPool } = await hubPoolFixture());
 
     // Create an alias for the Owner. Impersonate the account. Crate a signer for it and send it ETH.
     crossDomainAliasAddress = avmL1ToL2Alias(owner.address);
@@ -36,7 +36,7 @@ describe("Arbitrum Spoke Pool", function () {
 
     arbitrumSpokePool = await hre.upgrades.deployProxy(
       await getContractFactory("Arbitrum_SpokePool", owner),
-      [0, l2GatewayRouter.address, owner.address, hubPool.address, l2Weth],
+      [0, l2GatewayRouter.address, owner.address, hubPool.address],
       { kind: "uups", unsafeAllow: ["delegatecall"] }
     );
 

--- a/test/chain-specific-spokepools/Ethereum_SpokePool.ts
+++ b/test/chain-specific-spokepools/Ethereum_SpokePool.ts
@@ -15,7 +15,7 @@ describe("Ethereum Spoke Pool", function () {
 
     spokePool = await hre.upgrades.deployProxy(
       await getContractFactory("Ethereum_SpokePool", owner),
-      [0, hubPool.address, weth.address],
+      [0, hubPool.address],
       { kind: "uups", unsafeAllow: ["delegatecall"] }
     );
 


### PR DESCRIPTION
The motivation is to remove an unneccessary SLOAD to read `wrappedNativeToken` on each deposit since this address should never change after a SpokePool is deployed.

Unfortunately, we can't easily convert the existing variable to be an `immutable` variable since upgradeable contracts are not compatible easily with immutable variables [docs](https://docs.openzeppelin.com/upgrades-plugins/1.x/faq#why-cant-i-use-immutable-variables).

This variable is tricky to change to a constant also because it needs to change for each different child `SpokePool` contract implementation.

One way around it is is to rename but not remove the existing `wrappedNativeToken` variable to preserve the storage layout of the contract. Note, I **think** this is safe to do but I'm not sure. Then, declare an overridable `public` function `wrappedNativeToken` that we can reimplement in each child SpokePool to return a constant value. We also could make this function `internal` if that saves more gas versus calling a `public` function
@[nicholaspai](https://github.com/across-protocol/contracts-v2/commits?author=nicholaspai)
nicholaspai committed 1 hour ago