### PR TITLE
refactor(SpokePool): Remove token amount limits on depositUSS()

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -652,17 +652,11 @@ abstract contract SpokePool is
         // which is pulled from the relayer at fill time and passed through this contract atomically to the recipient.
         require(enabledDepositRoutes[inputToken.token][destinationChainId], "Disabled route");
 
-        // Sanity check output token amount to prevent depositor from griefing off-chainbots who need to compute
-        // this amount and may not be able to process such large numbers. Same with input token amount.
-        // @dev: Are these sanity checks useful or nice-to-have and are they worth the added gas cost?
-        require(inputToken.amount <= MAX_TRANSFER_SIZE && outputToken.amount <= MAX_TRANSFER_SIZE, "Amount too large");
-
         // Require that quoteTimestamp has a maximum age so that depositors pay an LP fee based on recent HubPool usage.
         // It is assumed that cross-chain timestamps are normally loosely in-sync, but clock drift can occur. If the
         // SpokePool time stalls or lags significantly, it is still possible to make deposits by setting quoteTimestamp
         // within the configured buffer. The owner should pause deposits if this is undesirable. This will underflow if
         // quoteTimestamp is more than depositQuoteTimeBuffer; this is safe but will throw an unintuitive error.
-
         // slither-disable-next-line timestamp
         require(getCurrentTime() - quoteTimestamp <= depositQuoteTimeBuffer, "invalid quoteTimestamp");
 


### PR DESCRIPTION
These checks shouldn't be necessary; it's up to relayer implementations to ensure that they are robust to the input and output token amounts.