### PR TITLE
fix: use updated deployNewProxy fn

### DIFF
--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -9,8 +9,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Optimism_SpokePool", initArgs, {
+  await deployNewProxy("Optimism_SpokePool", {
     constructorArgs: ["0x4200000000000000000000000000000000000006", 3600, 32400],
+    initArgs,
   });
 };
 module.exports = func;

--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -9,10 +9,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Optimism_SpokePool", {
-    constructorArgs: ["0x4200000000000000000000000000000000000006", 3600, 32400],
-    initArgs,
-  });
+  await deployNewProxy("Optimism_SpokePool", ["0x4200000000000000000000000000000000000006", 3600, 32400], initArgs);
 };
 module.exports = func;
 func.tags = ["OptimismSpokePool", "optimism"];

--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -9,7 +9,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Optimism_SpokePool", ["0x4200000000000000000000000000000000000006", 3600, 32400], initArgs);
+  const constructorArgs = ["0x4200000000000000000000000000000000000006", 3600, 32400];
+  await deployNewProxy("Optimism_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["OptimismSpokePool", "optimism"];

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -10,8 +10,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, L2_ADDRESS_MAP[spokeChainId].l2GatewayRouter, hubPool.address, hubPool.address];
-  await deployNewProxy("Arbitrum_SpokePool", initArgs, {
+  await deployNewProxy("Arbitrum_SpokePool", {
     constructorArgs: [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 32400],
+    initArgs,
   });
 };
 module.exports = func;

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -10,10 +10,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, L2_ADDRESS_MAP[spokeChainId].l2GatewayRouter, hubPool.address, hubPool.address];
-  await deployNewProxy("Arbitrum_SpokePool", {
-    constructorArgs: [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 32400],
-    initArgs,
-  });
+  await deployNewProxy("Arbitrum_SpokePool", [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 32400], initArgs);
 };
 module.exports = func;
 func.tags = ["ArbitrumSpokePool", "arbitrum"];

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -10,7 +10,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, L2_ADDRESS_MAP[spokeChainId].l2GatewayRouter, hubPool.address, hubPool.address];
-  await deployNewProxy("Arbitrum_SpokePool", [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 32400], initArgs);
+  const constructorArgs = [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 32400];
+  await deployNewProxy("Arbitrum_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["ArbitrumSpokePool", "arbitrum"];

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -12,10 +12,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.
   const initArgs = [1_000_000, hubPool.address, L1_ADDRESS_MAP[chainId].weth];
-  await deployNewProxy("Ethereum_SpokePool", {
-    constructorArgs: [L1_ADDRESS_MAP[chainId].weth, 3600, 32400],
-    initArgs,
-  });
+  await deployNewProxy("Ethereum_SpokePool", [L1_ADDRESS_MAP[chainId].weth, 3600, 32400], initArgs);
 
   // Transfer ownership to hub pool.
 };

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -12,8 +12,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.
   const initArgs = [1_000_000, hubPool.address, L1_ADDRESS_MAP[chainId].weth];
-  await deployNewProxy("Ethereum_SpokePool", initArgs, {
+  await deployNewProxy("Ethereum_SpokePool", {
     constructorArgs: [L1_ADDRESS_MAP[chainId].weth, 3600, 32400],
+    initArgs,
   });
 
   // Transfer ownership to hub pool.

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -11,8 +11,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
 
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.
-  const initArgs = [1_000_000, hubPool.address, L1_ADDRESS_MAP[chainId].weth];
-  await deployNewProxy("Ethereum_SpokePool", [L1_ADDRESS_MAP[chainId].weth, 3600, 32400], initArgs);
+  const initArgs = [1_000_000, hubPool.address];
+  const constructorArgs = [L1_ADDRESS_MAP[chainId].weth, 3600, 32400];
+  await deployNewProxy("Ethereum_SpokePool", constructorArgs, initArgs);
 
   // Transfer ownership to hub pool.
 };

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -18,8 +18,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     hubPool.address,
     L2_ADDRESS_MAP[spokeChainId].fxChild,
   ];
-  await deployNewProxy("Polygon_SpokePool", initArgs, {
+  await deployNewProxy("Polygon_SpokePool", {
     constructorArgs: [L2_ADDRESS_MAP[spokeChainId].wMatic, 3600, 32400],
+    initArgs,
   });
 };
 

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -18,7 +18,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     hubPool.address,
     L2_ADDRESS_MAP[spokeChainId].fxChild,
   ];
-  await deployNewProxy("Polygon_SpokePool", [L2_ADDRESS_MAP[spokeChainId].wMatic, 3600, 32400], initArgs);
+  const constructorArgs = [L2_ADDRESS_MAP[spokeChainId].wMatic, 3600, 32400];
+  await deployNewProxy("Polygon_SpokePool", constructorArgs, initArgs);
 };
 
 module.exports = func;

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -18,10 +18,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     hubPool.address,
     L2_ADDRESS_MAP[spokeChainId].fxChild,
   ];
-  await deployNewProxy("Polygon_SpokePool", {
-    constructorArgs: [L2_ADDRESS_MAP[spokeChainId].wMatic, 3600, 32400],
-    initArgs,
-  });
+  await deployNewProxy("Polygon_SpokePool", [L2_ADDRESS_MAP[spokeChainId].wMatic, 3600, 32400], initArgs);
 };
 
 module.exports = func;

--- a/deploy/013_deploy_boba_spokepool.ts
+++ b/deploy/013_deploy_boba_spokepool.ts
@@ -9,10 +9,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Boba_SpokePool", {
-    constructorArgs: ["0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000", 3600, 32400],
-    initArgs,
-  });
+  await deployNewProxy("Boba_SpokePool", ["0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000", 3600, 32400], initArgs);
 };
 module.exports = func;
 func.tags = ["BobaSpokePool", "boba"];

--- a/deploy/013_deploy_boba_spokepool.ts
+++ b/deploy/013_deploy_boba_spokepool.ts
@@ -9,8 +9,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Boba_SpokePool", initArgs, {
+  await deployNewProxy("Boba_SpokePool", {
     constructorArgs: ["0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000", 3600, 32400],
+    initArgs,
   });
 };
 module.exports = func;

--- a/deploy/013_deploy_boba_spokepool.ts
+++ b/deploy/013_deploy_boba_spokepool.ts
@@ -9,7 +9,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Boba_SpokePool", ["0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000", 3600, 32400], initArgs);
+  const constructorArgs = ["0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000", 3600, 32400];
+  await deployNewProxy("Boba_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["BobaSpokePool", "boba"];

--- a/deploy/025_deploy_base_spokepool.ts
+++ b/deploy/025_deploy_base_spokepool.ts
@@ -9,8 +9,9 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Base_SpokePool", initArgs, {
+  await deployNewProxy("Base_SpokePool", {
     constructorArgs: ["0x4200000000000000000000000000000000000006", 3600, 32400],
+    initArgs,
   });
 };
 module.exports = func;

--- a/deploy/025_deploy_base_spokepool.ts
+++ b/deploy/025_deploy_base_spokepool.ts
@@ -9,7 +9,8 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Base_SpokePool", ["0x4200000000000000000000000000000000000006", 3600, 32400], initArgs);
+  const constructorArgs = ["0x4200000000000000000000000000000000000006", 3600, 32400];
+  await deployNewProxy("Base_SpokePool", constructorArgs, initArgs);
 };
 module.exports = func;
 func.tags = ["BaseSpokePool", "base"];

--- a/deploy/025_deploy_base_spokepool.ts
+++ b/deploy/025_deploy_base_spokepool.ts
@@ -9,10 +9,7 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
-  await deployNewProxy("Base_SpokePool", {
-    constructorArgs: ["0x4200000000000000000000000000000000000006", 3600, 32400],
-    initArgs,
-  });
+  await deployNewProxy("Base_SpokePool", ["0x4200000000000000000000000000000000000006", 3600, 32400], initArgs);
 };
 module.exports = func;
 func.tags = ["BaseSpokePool", "base"];

--- a/utils/utils.hre.ts
+++ b/utils/utils.hre.ts
@@ -23,12 +23,20 @@ export async function getSpokePoolDeploymentInfo(
   return { hubPool, hubChainId, spokeChainId };
 }
 
-export async function deployNewProxy(name: string, args: (number | string)[]): Promise<void> {
+type FnArgs = number | string;
+type DeployOpts = {
+  constructorArgs: FnArgs[];
+  initFn?: string;
+  initArgs?: FnArgs[];
+};
+export async function deployNewProxy(name: string, args: DeployOpts): Promise<void> {
   const { deployments, run, upgrades } = hre;
 
-  const proxy = await upgrades.deployProxy(await getContractFactory(name, {}), args, {
+  const proxy = await upgrades.deployProxy(await getContractFactory(name, {}), args.initArgs ?? [], {
     kind: "uups",
     unsafeAllow: ["delegatecall"], // Remove after upgrading openzeppelin-contracts-upgradeable post v4.9.3.
+    initializer: args.initFn ?? "initialize",
+    constructorArgs: args.constructorArgs,
   });
   const instance = await proxy.deployed();
   console.log(`New ${name} proxy deployed @ ${instance.address}`);

--- a/utils/utils.hre.ts
+++ b/utils/utils.hre.ts
@@ -24,19 +24,14 @@ export async function getSpokePoolDeploymentInfo(
 }
 
 type FnArgs = number | string;
-type DeployOpts = {
-  constructorArgs: FnArgs[];
-  initFn?: string;
-  initArgs?: FnArgs[];
-};
-export async function deployNewProxy(name: string, args: DeployOpts): Promise<void> {
+export async function deployNewProxy(name: string, constructorArgs: FnArgs[], initArgs: FnArgs[]): Promise<void> {
   const { deployments, run, upgrades } = hre;
 
-  const proxy = await upgrades.deployProxy(await getContractFactory(name, {}), args.initArgs ?? [], {
+  const proxy = await upgrades.deployProxy(await getContractFactory(name, {}), initArgs, {
     kind: "uups",
     unsafeAllow: ["delegatecall"], // Remove after upgrading openzeppelin-contracts-upgradeable post v4.9.3.
-    initializer: args.initFn ?? "initialize",
-    constructorArgs: args.constructorArgs,
+    initializer: "initialize",
+    constructorArgs,
   });
   const instance = await proxy.deployed();
   console.log(`New ${name} proxy deployed @ ${instance.address}`);

--- a/utils/utils.hre.ts
+++ b/utils/utils.hre.ts
@@ -30,8 +30,8 @@ export async function deployNewProxy(name: string, constructorArgs: FnArgs[], in
   const proxy = await upgrades.deployProxy(await getContractFactory(name, {}), initArgs, {
     kind: "uups",
     unsafeAllow: ["delegatecall"], // Remove after upgrading openzeppelin-contracts-upgradeable post v4.9.3.
-    initializer: "initialize",
     constructorArgs,
+    initializer: "initialize",
   });
   const instance = await proxy.deployed();
   console.log(`New ${name} proxy deployed @ ${instance.address}`);
@@ -51,7 +51,7 @@ export async function deployNewProxy(name: string, constructorArgs: FnArgs[], in
   // is a proxy, hardhat will first verify the implementation and then the proxy and also link the proxy
   // to the implementation's ABI on etherscan.
   // https://docs.openzeppelin.com/upgrades-plugins/1.x/api-hardhat-upgrades#verify
-  await run("verify:verify", { address: instance.address });
+  await run("verify:verify", { address: instance.address, constructorArguments: constructorArgs });
 }
 
 export { hre };


### PR DESCRIPTION
The current references to `deployNewProxy` result in compilation errors. We should modify `deployNewProxy` so that it can pass an initializer & constructor args and call that fn correctly.