### PR TITLE
feat(SpokePool): Require executeX() caller to be EOA

### DIFF
--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -249,7 +249,7 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
         if (funcLocks[funcIdentifier] != lockValue) funcLocks[funcIdentifier] = lockValue;
     }
 
-    // Revert if function was called during this block
+    // Revert if function was called during this block with the same tx.origin.
     function _revertIfFunctionCalledAtomically(bytes32 funcIdentifier) internal view {
         // solhint-disable-next-line not-rely-on-time, avoid-tx-origin
         if (funcLocks[funcIdentifier] == keccak256(abi.encodePacked(block.timestamp, tx.origin)))

--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -164,6 +164,30 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
         _wrap();
     }
 
+    /**
+     * @notice These functions can send an L2 to L1 message so we are extra cautious about preventing a griefing vector
+     * whereby someone batches this call with a bunch of other calls and produces a very large L2 burn transaction.
+     * This might make the L2 -> L1 message fail due to exceeding the L1 calldata limit.
+     */
+
+    function executeUSSRelayerRefundLeaf(
+        uint32 rootBundleId,
+        USSRelayerRefundLeaf memory relayerRefundLeaf,
+        bytes32[] memory proof
+    ) public override {
+        if (relayerRefundLeaf.amountToReturn > 0 && AddressLibUpgradeable.isContract(msg.sender)) revert NotEOA();
+        super.executeUSSRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
+    }
+
+    function executeRelayerRefundLeaf(
+        uint32 rootBundleId,
+        SpokePoolInterface.RelayerRefundLeaf memory relayerRefundLeaf,
+        bytes32[] memory proof
+    ) public override {
+        if (relayerRefundLeaf.amountToReturn > 0 && AddressLibUpgradeable.isContract(msg.sender)) revert NotEOA();
+        super.executeRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
+    }
+
     /**************************************
      *        INTERNAL FUNCTIONS          *
      **************************************/

--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -175,7 +175,11 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
         USSRelayerRefundLeaf memory relayerRefundLeaf,
         bytes32[] memory proof
     ) public override {
-        if (relayerRefundLeaf.amountToReturn > 0 && AddressLibUpgradeable.isContract(msg.sender)) revert NotEOA();
+        // AddressLibUpgradeable.isContract isn't a sufficient check because it checks the contract code size of
+        // msg.sender which is 0 if called from a constructor function on msg.sender. This is why we check if
+        // msg.sender is equal to tx.origin which is fine as long as Polygon supports the tx.origin opcode.
+        // solhint-disable-next-line avoid-tx-origin
+        if (relayerRefundLeaf.amountToReturn > 0 && msg.sender != tx.origin) revert NotEOA();
         super.executeUSSRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
     }
 
@@ -184,7 +188,11 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
         SpokePoolInterface.RelayerRefundLeaf memory relayerRefundLeaf,
         bytes32[] memory proof
     ) public override {
-        if (relayerRefundLeaf.amountToReturn > 0 && AddressLibUpgradeable.isContract(msg.sender)) revert NotEOA();
+        // AddressLibUpgradeable.isContract isn't a sufficient check because it checks the contract code size of
+        // msg.sender which is 0 if called from a constructor function on msg.sender. This is why we check if
+        // msg.sender is equal to tx.origin which is fine as long as Polygon supports the tx.origin opcode.
+        // solhint-disable-next-line avoid-tx-origin
+        if (relayerRefundLeaf.amountToReturn > 0 && msg.sender != tx.origin) revert NotEOA();
         super.executeRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
     }
 

--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -243,16 +243,17 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
         if (balance > 0) wrappedNativeToken.deposit{ value: balance }();
     }
 
-    function _setFunctionLock(bytes32 funcSig) internal {
+    function _setFunctionLock(bytes32 funcIdentifier) internal {
         // solhint-disable-next-line not-rely-on-time, avoid-tx-origin
         bytes32 lockValue = keccak256(abi.encodePacked(block.timestamp, tx.origin));
-        if (funcLocks[funcSig] != lockValue) funcLocks[funcSig] = lockValue;
+        if (funcLocks[funcIdentifier] != lockValue) funcLocks[funcIdentifier] = lockValue;
     }
 
     // Revert if function was called during this block
-    function _revertIfFunctionCalledAtomically(bytes32 funcSig) internal view {
+    function _revertIfFunctionCalledAtomically(bytes32 funcIdentifier) internal view {
         // solhint-disable-next-line not-rely-on-time, avoid-tx-origin
-        if (funcLocks[funcSig] == keccak256(abi.encodePacked(block.timestamp, tx.origin))) revert CrossFunctionLock();
+        if (funcLocks[funcIdentifier] == keccak256(abi.encodePacked(block.timestamp, tx.origin)))
+            revert CrossFunctionLock();
     }
 
     // @dev: This contract will trigger admin functions internally via the `processMessageFromRoot`, which is why

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1393,6 +1393,8 @@ abstract contract SpokePool is
         // This method by default is a no-op. Different child spoke pools might want to execute functionality here
         // such as wrapping any native tokens owned by the contract into wrapped tokens before proceeding with
         // executing the leaf.
+
+        if (address(msg.sender).isContract()) revert NotEOA();
     }
 
     // Should be overriden by implementing contract depending on how L2 handles sending tokens to L1.

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1680,7 +1680,7 @@ abstract contract SpokePool is
         bytes memory updatedMessage = relayExecution.updatedMessage;
         if (recipientToSend.isContract() && updatedMessage.length > 0) {
             _preHandleMessageHook();
-            AcrossMessageHandler(recipientToSend).handleAcrossMessage(
+            AcrossMessageHandler(recipientToSend).handleUSSAcrossMessage(
                 outputToken,
                 amountToSend,
                 msg.sender,

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1662,6 +1662,7 @@ abstract contract SpokePool is
         }
 
         if (relayExecution.updatedRecipient.isContract() && relayExecution.updatedMessage.length > 0) {
+            _preHandleMessageHook();
             AcrossMessageHandler(relayExecution.updatedRecipient).handleAcrossMessage(
                 relayData.destinationToken,
                 amountToSend,
@@ -1670,6 +1671,10 @@ abstract contract SpokePool is
                 relayExecution.updatedMessage
             );
         }
+    }
+
+    function _preHandleMessageHook() internal virtual {
+        // This method by default is a no-op.
     }
 
     // @param relayer: relayer who is actually credited as filling this deposit. Can be different from

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1120,7 +1120,7 @@ abstract contract SpokePool is
         uint32 rootBundleId,
         SpokePoolInterface.RelayerRefundLeaf memory relayerRefundLeaf,
         bytes32[] memory proof
-    ) public override nonReentrant {
+    ) public virtual override nonReentrant {
         _preExecuteLeafHook(relayerRefundLeaf.l2TokenAddress);
 
         _validateRelayerRefundLeaf(
@@ -1170,7 +1170,7 @@ abstract contract SpokePool is
         uint32 rootBundleId,
         USSSpokePoolInterface.USSRelayerRefundLeaf memory relayerRefundLeaf,
         bytes32[] memory proof
-    ) public override nonReentrant {
+    ) public virtual override nonReentrant {
         _preExecuteLeafHook(relayerRefundLeaf.l2TokenAddress);
 
         _validateRelayerRefundLeaf(
@@ -1389,12 +1389,10 @@ abstract contract SpokePool is
         emit SetHubPool(newHubPool);
     }
 
-    function _preExecuteLeafHook(address l2TokenAddress) internal virtual {
+    function _preExecuteLeafHook(address) internal virtual {
         // This method by default is a no-op. Different child spoke pools might want to execute functionality here
         // such as wrapping any native tokens owned by the contract into wrapped tokens before proceeding with
         // executing the leaf.
-
-        if (address(msg.sender).isContract()) revert NotEOA();
     }
 
     // Should be overriden by implementing contract depending on how L2 handles sending tokens to L1.

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1772,6 +1772,7 @@ abstract contract SpokePool is
         // require integrators sign-off.
         bytes memory updatedMessage = relayExecution.updatedMessage;
         if (recipientToSend.isContract() && updatedMessage.length > 0) {
+            _preHandleMessageHook();
             AcrossMessageHandler(recipientToSend).handleAcrossMessage(
                 outputToken,
                 amountToSend,

--- a/contracts/interfaces/SpokePoolInterface.sol
+++ b/contracts/interfaces/SpokePoolInterface.sol
@@ -183,4 +183,6 @@ interface SpokePoolInterface {
     ) external;
 
     function chainId() external view returns (uint256);
+
+    error NotEOA();
 }

--- a/contracts/test/MockCaller.sol
+++ b/contracts/test/MockCaller.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity ^0.8.0;
+
+import "../interfaces/USSSpokePoolInterface.sol";
+
+// Used for calling SpokePool.sol functions from a contract instead of an EOA. Can be used to simulate aggregator
+// or pooled relayer behavior.
+contract MockCaller {
+    USSSpokePoolInterface private spokePool;
+
+    constructor(address _spokePool) {
+        require(_spokePool != address(this), "spokePool not external");
+        spokePool = USSSpokePoolInterface(_spokePool);
+    }
+
+    function executeRelayerRefundLeaf(
+        uint32 rootBundleId,
+        USSSpokePoolInterface.USSRelayerRefundLeaf memory relayerRefundLeaf,
+        bytes32[] memory proof
+    ) external {
+        spokePool.executeUSSRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
+    }
+
+    function executeSlowRelayLeaf(
+        USSSpokePoolInterface.USSSlowFill memory slowFillLeaf,
+        uint32 rootBundleId,
+        bytes32[] memory proof
+    ) external {
+        spokePool.executeUSSSlowRelayLeaf(slowFillLeaf, rootBundleId, proof);
+    }
+}

--- a/contracts/test/MockCaller.sol
+++ b/contracts/test/MockCaller.sol
@@ -5,28 +5,29 @@ import "../interfaces/USSSpokePoolInterface.sol";
 import "../interfaces/SpokePoolInterface.sol";
 
 // Used for calling SpokePool.sol functions from a contract instead of an EOA. Can be used to simulate aggregator
-// or pooled relayer behavior.
-contract MockCaller {
-    address private spokePool;
+// or pooled relayer behavior. Makes all calls from constructor to make sure SpokePool is not relying on checking the
+// caller's code size which is 0 at construction time.
 
-    constructor(address _spokePool) {
-        require(_spokePool != address(this), "spokePool not external");
-        spokePool = _spokePool;
-    }
-
-    function executeUSSRelayerRefundLeaf(
+contract MockUSSCaller {
+    constructor(
+        address _spokePool,
         uint32 rootBundleId,
         USSSpokePoolInterface.USSRelayerRefundLeaf memory relayerRefundLeaf,
         bytes32[] memory proof
-    ) external {
-        USSSpokePoolInterface(spokePool).executeUSSRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
+    ) {
+        require(_spokePool != address(this), "spokePool not external");
+        USSSpokePoolInterface(_spokePool).executeUSSRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
     }
+}
 
-    function executeRelayerRefundLeaf(
+contract MockCaller {
+    constructor(
+        address _spokePool,
         uint32 rootBundleId,
         SpokePoolInterface.RelayerRefundLeaf memory relayerRefundLeaf,
         bytes32[] memory proof
-    ) external {
-        SpokePoolInterface(spokePool).executeRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
+    ) {
+        require(_spokePool != address(this), "spokePool not external");
+        SpokePoolInterface(_spokePool).executeRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
     }
 }

--- a/contracts/test/MockCaller.sol
+++ b/contracts/test/MockCaller.sol
@@ -2,30 +2,31 @@
 pragma solidity ^0.8.0;
 
 import "../interfaces/USSSpokePoolInterface.sol";
+import "../interfaces/SpokePoolInterface.sol";
 
 // Used for calling SpokePool.sol functions from a contract instead of an EOA. Can be used to simulate aggregator
 // or pooled relayer behavior.
 contract MockCaller {
-    USSSpokePoolInterface private spokePool;
+    address private spokePool;
 
     constructor(address _spokePool) {
         require(_spokePool != address(this), "spokePool not external");
-        spokePool = USSSpokePoolInterface(_spokePool);
+        spokePool = _spokePool;
     }
 
-    function executeRelayerRefundLeaf(
+    function executeUSSRelayerRefundLeaf(
         uint32 rootBundleId,
         USSSpokePoolInterface.USSRelayerRefundLeaf memory relayerRefundLeaf,
         bytes32[] memory proof
     ) external {
-        spokePool.executeUSSRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
+        USSSpokePoolInterface(spokePool).executeUSSRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
     }
 
-    function executeSlowRelayLeaf(
-        USSSpokePoolInterface.USSSlowFill memory slowFillLeaf,
+    function executeRelayerRefundLeaf(
         uint32 rootBundleId,
+        SpokePoolInterface.RelayerRefundLeaf memory relayerRefundLeaf,
         bytes32[] memory proof
     ) external {
-        spokePool.executeUSSSlowRelayLeaf(slowFillLeaf, rootBundleId, proof);
+        SpokePoolInterface(spokePool).executeRelayerRefundLeaf(rootBundleId, relayerRefundLeaf, proof);
     }
 }

--- a/test/MerkleLib.utils.ts
+++ b/test/MerkleLib.utils.ts
@@ -174,8 +174,8 @@ export async function buildSlowRelayTree(slowFills: SlowFill[]) {
 }
 export async function buildUSSSlowRelayTree(slowFills: USSSlowFill[]) {
   const paramType = await getParamType("MerkleLibTest", "verifyUSSSlowRelayFulfillment", "slowFill");
-  const hashFn = (input: SlowFill) => {
+  const hashFn = (input: USSSlowFill) => {
     return keccak256(defaultAbiCoder.encode([paramType!], [input]));
   };
-  return new MerkleTree<SlowFill>(slowFills, hashFn);
+  return new MerkleTree<USSSlowFill>(slowFills, hashFn);
 }

--- a/test/MerkleLib.utils.ts
+++ b/test/MerkleLib.utils.ts
@@ -1,7 +1,7 @@
 import { getParamType, expect, BigNumber, Contract, defaultAbiCoder, keccak256, toBNWei } from "../utils/utils";
 import { repaymentChainId, amountToReturn } from "./constants";
 import { MerkleTree } from "../utils/MerkleTree";
-import { SlowFill } from "./fixtures/SpokePool.Fixture";
+import { SlowFill, USSSlowFill } from "./fixtures/SpokePool.Fixture";
 export interface PoolRebalanceLeaf {
   chainId: BigNumber;
   groupIndex: BigNumber;
@@ -37,6 +37,17 @@ export async function buildRelayerRefundTree(relayerRefundLeaves: RelayerRefundL
   return new MerkleTree<RelayerRefundLeaf>(relayerRefundLeaves, hashFn);
 }
 
+export async function buildUSSRelayerRefundTree(relayerRefundLeaves: USSRelayerRefundLeaf[]) {
+  for (let i = 0; i < relayerRefundLeaves.length; i++) {
+    // The 2 provided parallel arrays must be of equal length.
+    expect(relayerRefundLeaves[i].refundAddresses.length).to.equal(relayerRefundLeaves[i].refundAmounts.length);
+  }
+
+  const paramType = await getParamType("MerkleLibTest", "verifyUSSRelayerRefund", "refund");
+  const hashFn = (input: USSRelayerRefundLeaf) => keccak256(defaultAbiCoder.encode([paramType!], [input]));
+  return new MerkleTree<USSRelayerRefundLeaf>(relayerRefundLeaves, hashFn);
+}
+
 export function buildRelayerRefundLeaves(
   destinationChainIds: number[],
   amountsToReturn: BigNumber[],
@@ -54,6 +65,31 @@ export function buildRelayerRefundLeaves(
         l2TokenAddress: l2Tokens[i],
         refundAddresses: refundAddresses[i],
         refundAmounts: refundAmounts[i],
+      };
+    });
+}
+
+export function buildUSSRelayerRefundLeaves(
+  destinationChainIds: number[],
+  amountsToReturn: BigNumber[],
+  l2Tokens: string[],
+  refundAddresses: string[][],
+  refundAmounts: BigNumber[][],
+  fillsRefundedRoot: string[],
+  fillsRefundedHash: string[]
+): USSRelayerRefundLeaf[] {
+  return Array(destinationChainIds.length)
+    .fill(0)
+    .map((_, i) => {
+      return {
+        leafId: BigNumber.from(i),
+        chainId: BigNumber.from(destinationChainIds[i]),
+        amountToReturn: amountsToReturn[i],
+        l2TokenAddress: l2Tokens[i],
+        refundAddresses: refundAddresses[i],
+        refundAmounts: refundAmounts[i],
+        fillsRefundedRoot: fillsRefundedRoot[i],
+        fillsRefundedHash: fillsRefundedHash[i],
       };
     });
 }
@@ -131,6 +167,13 @@ export async function constructSingleChainTree(token: string, scalingSize = 1, r
 
 export async function buildSlowRelayTree(slowFills: SlowFill[]) {
   const paramType = await getParamType("MerkleLibTest", "verifySlowRelayFulfillment", "slowFill");
+  const hashFn = (input: SlowFill) => {
+    return keccak256(defaultAbiCoder.encode([paramType!], [input]));
+  };
+  return new MerkleTree<SlowFill>(slowFills, hashFn);
+}
+export async function buildUSSSlowRelayTree(slowFills: USSSlowFill[]) {
+  const paramType = await getParamType("MerkleLibTest", "verifyUSSSlowRelayFulfillment", "slowFill");
   const hashFn = (input: SlowFill) => {
     return keccak256(defaultAbiCoder.encode([paramType!], [input]));
   };

--- a/test/SpokePool.ExecuteRootBundle.ts
+++ b/test/SpokePool.ExecuteRootBundle.ts
@@ -1,3 +1,4 @@
+import { MerkleTree } from "../utils/MerkleTree";
 import { SignerWithAddress, seedContract, toBN, expect, Contract, ethers, BigNumber } from "../utils/utils";
 import * as consts from "./constants";
 import { deployMockSpokePoolCaller, spokePoolFixture } from "./fixtures/SpokePool.Fixture";
@@ -140,13 +141,6 @@ describe("SpokePool Root Bundle Execution", function () {
     it("Can execute ERC20 leaf", async function () {
       await spokePool.connect(dataWorker).relayRootBundle(tree.getHexRoot(), consts.mockSlowRelayRoot);
       await spokePool.connect(dataWorker).executeUSSRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]));
-    });
-    it("Must be EOA to execute", async function () {
-      await spokePool.connect(dataWorker).relayRootBundle(tree.getHexRoot(), consts.mockSlowRelayRoot);
-      const nonEOACaller = await deployMockSpokePoolCaller(spokePool);
-      await expect(
-        nonEOACaller.connect(dataWorker).executeRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]))
-      ).to.revertedWith("NotEOA");
     });
   });
 

--- a/test/SpokePool.ExecuteRootBundle.ts
+++ b/test/SpokePool.ExecuteRootBundle.ts
@@ -1,7 +1,13 @@
 import { SignerWithAddress, seedContract, toBN, expect, Contract, ethers, BigNumber } from "../utils/utils";
 import * as consts from "./constants";
-import { spokePoolFixture } from "./fixtures/SpokePool.Fixture";
-import { buildRelayerRefundTree, buildRelayerRefundLeaves } from "./MerkleLib.utils";
+import { deployMockSpokePoolCaller, spokePoolFixture } from "./fixtures/SpokePool.Fixture";
+import {
+  buildRelayerRefundTree,
+  buildRelayerRefundLeaves,
+  USSRelayerRefundLeaf,
+  buildUSSRelayerRefundLeaves,
+  buildUSSRelayerRefundTree,
+} from "./MerkleLib.utils";
 
 let spokePool: Contract, destErc20: Contract, weth: Contract;
 let dataWorker: SignerWithAddress, relayer: SignerWithAddress, rando: SignerWithAddress;
@@ -115,6 +121,33 @@ describe("SpokePool Root Bundle Execution", function () {
     await spokePool.connect(dataWorker).executeRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]));
     await expect(spokePool.connect(dataWorker).executeRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]))).to
       .be.reverted;
+  });
+
+  describe("USS relayer refund leaves", function () {
+    let leaves: USSRelayerRefundLeaf[], tree: MerkleTree<USSRelayerRefundLeaf>;
+    beforeEach(async function () {
+      leaves = buildUSSRelayerRefundLeaves(
+        [destinationChainId, destinationChainId], // Destination chain ID.
+        [consts.amountToReturn, toBN(0)], // amountToReturn.
+        [destErc20.address, destErc20.address], // l2Token.
+        [[relayer.address, rando.address], []], // refundAddresses.
+        [[consts.amountToRelay, consts.amountToRelay], []], // refundAmounts.
+        [consts.mockTreeRoot, consts.mockTreeRoot], // fillsRefundedRoot.
+        [consts.mockTreeRoot, consts.mockTreeRoot] // fillsRefundedHash.
+      );
+      tree = await buildUSSRelayerRefundTree(leaves);
+    });
+    it("Can execute ERC20 leaf", async function () {
+      await spokePool.connect(dataWorker).relayRootBundle(tree.getHexRoot(), consts.mockSlowRelayRoot);
+      await spokePool.connect(dataWorker).executeUSSRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]));
+    });
+    it("Must be EOA to execute", async function () {
+      await spokePool.connect(dataWorker).relayRootBundle(tree.getHexRoot(), consts.mockSlowRelayRoot);
+      const nonEOACaller = await deployMockSpokePoolCaller(spokePool);
+      await expect(
+        nonEOACaller.connect(dataWorker).executeRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]))
+      ).to.revertedWith("NotEOA");
+    });
   });
 
   describe("Gas test", function () {

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -9,7 +9,6 @@ import {
   randomBigNumber,
   BigNumber,
   toWei,
-  getContractFactory,
 } from "../utils/utils";
 import {
   spokePoolFixture,

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -9,6 +9,7 @@ import {
   randomBigNumber,
   BigNumber,
   toWei,
+  getContractFactory,
 } from "../utils/utils";
 import {
   spokePoolFixture,
@@ -17,10 +18,11 @@ import {
   SlowFill,
   USSRelayData,
   getUSSRelayHash,
+  USSSlowFill,
 } from "./fixtures/SpokePool.Fixture";
 import { getFillRelayParams, getRelayHash } from "./fixtures/SpokePool.Fixture";
 import { MerkleTree } from "../utils/MerkleTree";
-import { buildSlowRelayTree } from "./MerkleLib.utils";
+import { buildSlowRelayTree, buildUSSSlowRelayTree } from "./MerkleLib.utils";
 import * as consts from "./constants";
 import { FillStatus } from "../utils/constants";
 
@@ -618,6 +620,67 @@ describe("SpokePool Slow Relay Logic", async function () {
 
       await expect(spokePool.connect(relayer).requestUSSSlowFill(relayData)).to.be.revertedWith(
         "InvalidSlowFillRequest"
+      );
+    });
+  });
+  describe("executeUSSSlowRelayLeaf", function () {
+    let relayData: USSRelayData, slowRelayLeaf: USSSlowFill;
+    beforeEach(async function () {
+      const fillDeadline = (await spokePool.getCurrentTime()).toNumber() + 1000;
+      relayData = {
+        depositor: depositor.address,
+        recipient: recipient.address,
+        exclusiveRelayer: relayer.address,
+        inputToken: erc20.address,
+        outputToken: destErc20.address,
+        inputAmount: consts.amountToDeposit,
+        outputAmount: fullRelayAmountPostFees,
+        originChainId: consts.originChainId,
+        destinationChainId: consts.destinationChainId,
+        depositId: consts.firstDepositId,
+        fillDeadline: fillDeadline,
+        exclusivityDeadline: fillDeadline - 500,
+        message: "0x",
+      };
+      slowRelayLeaf = {
+        relayData,
+        updatedOutputAmount: relayData.outputAmount,
+      };
+    });
+    it("can send ERC20 with correct proof", async function () {
+      const tree = await buildUSSSlowRelayTree([slowRelayLeaf]);
+      await spokePool.connect(depositor).relayRootBundle(consts.mockTreeRoot, tree.getHexRoot());
+      await expect(() =>
+        spokePool
+          .connect(relayer)
+          .executeUSSSlowRelayLeaf(
+            slowRelayLeaf,
+            1, // rootBundleId
+            tree.getHexProof(slowRelayLeaf)
+          )
+          .to.changeTokenBalances(
+            destErc20,
+            [spokePool, recipient],
+            [slowRelayLeaf.updatedOutputAmount.mul(-1), slowRelayLeaf.updatedOutputAmount]
+          )
+      );
+    });
+    it("must be called by EOA", async function () {
+      const tree = await buildUSSSlowRelayTree([slowRelayLeaf]);
+      await spokePool.connect(depositor).relayRootBundle(consts.mockTreeRoot, tree.getHexRoot());
+
+      const nonEOACaller = await (
+        await getContractFactory("MockCaller", (await ethers.getSigners())[0])
+      ).deploy(spokePool.address);
+      await expect(() =>
+        nonEOACaller
+          .connect(relayer)
+          .executeUSSSlowRelayLeaf(
+            slowRelayLeaf,
+            1, // rootBundleId
+            tree.getHexProof(slowRelayLeaf)
+          )
+          .to.revertedWith("NotEOA")
       );
     });
   });

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -665,23 +665,5 @@ describe("SpokePool Slow Relay Logic", async function () {
           )
       );
     });
-    it("must be called by EOA", async function () {
-      const tree = await buildUSSSlowRelayTree([slowRelayLeaf]);
-      await spokePool.connect(depositor).relayRootBundle(consts.mockTreeRoot, tree.getHexRoot());
-
-      const nonEOACaller = await (
-        await getContractFactory("MockCaller", (await ethers.getSigners())[0])
-      ).deploy(spokePool.address);
-      await expect(() =>
-        nonEOACaller
-          .connect(relayer)
-          .executeUSSSlowRelayLeaf(
-            slowRelayLeaf,
-            1, // rootBundleId
-            tree.getHexProof(slowRelayLeaf)
-          )
-          .to.revertedWith("NotEOA")
-      );
-    });
   });
 });

--- a/test/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -1,4 +1,11 @@
-import { mockTreeRoot, amountToReturn, amountHeldByPool, zeroAddress, TokenRolesEnum } from "../constants";
+import {
+  mockTreeRoot,
+  amountToReturn,
+  amountHeldByPool,
+  zeroAddress,
+  TokenRolesEnum,
+  originChainId,
+} from "../constants";
 import {
   ethers,
   expect,
@@ -22,7 +29,12 @@ import {
   constructSingleRelayerRefundTree,
 } from "../MerkleLib.utils";
 import { randomBytes } from "crypto";
-import { deployMockSpokePoolCaller, deployMockUSSSpokePoolCaller } from "../fixtures/SpokePool.Fixture";
+import {
+  deployMockSpokePoolCaller,
+  deployMockUSSSpokePoolCaller,
+  getFillRelayParams,
+  getRelayHash,
+} from "../fixtures/SpokePool.Fixture";
 
 let hubPool: Contract, polygonSpokePool: Contract, dai: Contract, weth: Contract, l2Dai: string;
 let polygonRegistry: FakeContract, erc20Predicate: FakeContract;
@@ -292,6 +304,102 @@ describe("Polygon Spoke Pool", function () {
     // Executing leaf with amountToReturn == 0 is fine through contract caller.
     await expect(deployMockSpokePoolCaller(polygonSpokePool, 0, leaves[1], tree.getHexProof(leaves[1]))).to.not.be
       .reverted;
+  });
+
+  it("Cannot combine fill and execute leaf functions in same tx", async function () {
+    const l2ChainId = await owner.getChainId();
+    const leaves = buildRelayerRefundLeaves(
+      [l2ChainId, l2ChainId], // Destination chain ID.
+      [ethers.constants.Zero, ethers.constants.Zero], // amountToReturn.
+      [dai.address, dai.address], // l2Token.
+      [[], []], // refundAddresses.
+      [[], []] // refundAmounts.
+    );
+    const tree = await buildRelayerRefundTree(leaves);
+
+    // Relay leaves to Spoke
+    const relayRootBundleData = polygonSpokePool.interface.encodeFunctionData("relayRootBundle", [
+      tree.getHexRoot(),
+      mockTreeRoot,
+    ]);
+    await polygonSpokePool.connect(fxChild).processMessageFromRoot(0, owner.address, relayRootBundleData);
+
+    // Deploy message handler and create fill with message that should succeed in isolation:
+    const acrossMessageHandler = await createFake("AcrossMessageHandlerMock");
+    await seedWallet(relayer, [dai], weth, toWei("2"));
+    await dai.connect(relayer).approve(polygonSpokePool.address, toWei("2"));
+
+    const executeLeafData = [
+      polygonSpokePool.interface.encodeFunctionData("executeRelayerRefundLeaf", [
+        0,
+        leaves[0],
+        tree.getHexProof(leaves[0]),
+      ]),
+      polygonSpokePool.interface.encodeFunctionData("executeRelayerRefundLeaf", [
+        0,
+        leaves[1],
+        tree.getHexProof(leaves[1]),
+      ]),
+    ];
+    const fillData = [
+      polygonSpokePool.interface.encodeFunctionData("fillRelay", [
+        ...getFillRelayParams(
+          getRelayHash(
+            owner.address,
+            acrossMessageHandler.address,
+            0, // deposit Id
+            originChainId,
+            l2ChainId,
+            dai.address,
+            undefined,
+            undefined,
+            undefined,
+            "0x1234"
+          ).relayData,
+          toWei("1"),
+          l2ChainId
+        ),
+      ]),
+      polygonSpokePool.interface.encodeFunctionData("fillRelay", [
+        ...getFillRelayParams(
+          getRelayHash(
+            owner.address,
+            acrossMessageHandler.address,
+            1, // deposit Id
+            originChainId,
+            l2ChainId,
+            dai.address,
+            undefined,
+            undefined,
+            undefined,
+            "0x1234"
+          ).relayData,
+          toWei("1"),
+          l2ChainId
+        ),
+      ]),
+    ];
+
+    // Fills and execute leaf should succeed in isolation:
+    // 1. Two fills
+    // 2. One fill
+    // 3. Two execution leaves
+    // 4. One execution leaf
+    await expect(polygonSpokePool.connect(relayer).estimateGas.multicall(fillData)).to.not.be.reverted;
+    await expect(polygonSpokePool.connect(relayer).estimateGas.multicall([fillData[0]])).to.not.be.reverted;
+    await expect(polygonSpokePool.connect(relayer).estimateGas.multicall(executeLeafData)).to.not.be.reverted;
+    await expect(polygonSpokePool.connect(relayer).estimateGas.multicall([executeLeafData[0]])).to.not.be.reverted;
+
+    // When combining fills and executions in any order, reverts.
+    // @dev: multicall() seems to suppress specific revert message so we can't use revertedWith()
+    await expect(polygonSpokePool.connect(relayer).multicall([...fillData, ...executeLeafData])).to.be.reverted;
+    await expect(polygonSpokePool.connect(relayer).multicall([...executeLeafData, ...fillData])).to.be.reverted;
+    await expect(
+      polygonSpokePool.connect(relayer).multicall([fillData[0], executeLeafData[0], fillData[1], executeLeafData[1]])
+    ).to.be.reverted;
+    await expect(
+      polygonSpokePool.connect(relayer).multicall([executeLeafData[0], fillData[0], executeLeafData[1], fillData[1]])
+    ).to.be.reverted;
   });
 
   it("PolygonTokenBridger retrieves and unwraps tokens correctly", async function () {

--- a/test/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -5,6 +5,7 @@ import {
   zeroAddress,
   TokenRolesEnum,
   originChainId,
+  maxUint256,
 } from "../constants";
 import {
   ethers,
@@ -402,6 +403,85 @@ describe("Polygon Spoke Pool", function () {
     ).to.be.reverted;
   });
 
+  it("Cannot combine fill and execute USS leaf functions in same tx", async function () {
+    const l2ChainId = await owner.getChainId();
+    const leaves = buildUSSRelayerRefundLeaves(
+      [l2ChainId, l2ChainId], // Destination chain ID.
+      [ethers.constants.Zero, ethers.constants.Zero], // amountToReturn.
+      [dai.address, dai.address], // l2Token.
+      [[], []], // refundAddresses.
+      [[], []], // refundAmounts.
+      [mockTreeRoot, mockTreeRoot], // fillsRefundedRoot.
+      [mockTreeRoot, mockTreeRoot] // fillsRefundedHash.
+    );
+    const tree = await buildUSSRelayerRefundTree(leaves);
+
+    // Relay leaves to Spoke
+    const relayRootBundleData = polygonSpokePool.interface.encodeFunctionData("relayRootBundle", [
+      tree.getHexRoot(),
+      mockTreeRoot,
+    ]);
+    await polygonSpokePool.connect(fxChild).processMessageFromRoot(0, owner.address, relayRootBundleData);
+
+    // Deploy message handler and create fill with message that should succeed in isolation:
+    const acrossMessageHandler = await createFake("AcrossMessageHandlerMock");
+    await seedWallet(relayer, [dai], weth, toWei("2"));
+    await dai.connect(relayer).approve(polygonSpokePool.address, toWei("2"));
+
+    const executeLeafData = [
+      polygonSpokePool.interface.encodeFunctionData("executeUSSRelayerRefundLeaf", [
+        0,
+        leaves[0],
+        tree.getHexProof(leaves[0]),
+      ]),
+      polygonSpokePool.interface.encodeFunctionData("executeUSSRelayerRefundLeaf", [
+        0,
+        leaves[1],
+        tree.getHexProof(leaves[1]),
+      ]),
+    ];
+    const relayData = {
+      depositor: owner.address,
+      recipient: acrossMessageHandler.address,
+      exclusiveRelayer: relayer.address,
+      inputToken: dai.address,
+      outputToken: dai.address,
+      inputAmount: toWei("1"),
+      outputAmount: toWei("1"),
+      originChainId,
+      destinationChainId: l2ChainId,
+      depositId: 0,
+      fillDeadline: (await polygonSpokePool.getCurrentTime()).toNumber() + 1000,
+      exclusivityDeadline: 0,
+      message: "0x1234",
+    };
+
+    const fillData = [
+      polygonSpokePool.interface.encodeFunctionData("fillUSSRelay", [relayData, l2ChainId]),
+      polygonSpokePool.interface.encodeFunctionData("fillUSSRelay", [{ ...relayData, depositId: 1 }, l2ChainId]),
+    ];
+
+    // Fills and execute leaf should succeed in isolation:
+    // 1. Two fills
+    // 2. One fill
+    // 3. Two execution leaves
+    // 4. One execution leaf
+    await expect(polygonSpokePool.connect(relayer).estimateGas.multicall(fillData)).to.not.be.reverted;
+    await expect(polygonSpokePool.connect(relayer).estimateGas.multicall([fillData[0]])).to.not.be.reverted;
+    await expect(polygonSpokePool.connect(relayer).estimateGas.multicall(executeLeafData)).to.not.be.reverted;
+    await expect(polygonSpokePool.connect(relayer).estimateGas.multicall([executeLeafData[0]])).to.not.be.reverted;
+
+    // When combining fills and executions in any order, reverts.
+    // @dev: multicall() seems to suppress specific revert message so we can't use revertedWith()
+    await expect(polygonSpokePool.connect(relayer).multicall([...fillData, ...executeLeafData])).to.be.reverted;
+    await expect(polygonSpokePool.connect(relayer).multicall([...executeLeafData, ...fillData])).to.be.reverted;
+    await expect(
+      polygonSpokePool.connect(relayer).multicall([fillData[0], executeLeafData[0], fillData[1], executeLeafData[1]])
+    ).to.be.reverted;
+    await expect(
+      polygonSpokePool.connect(relayer).multicall([executeLeafData[0], fillData[0], executeLeafData[1], fillData[1]])
+    ).to.be.reverted;
+  });
   it("PolygonTokenBridger retrieves and unwraps tokens correctly", async function () {
     const l1ChainId = await owner.getChainId();
 

--- a/test/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -22,7 +22,7 @@ import {
   constructSingleRelayerRefundTree,
 } from "../MerkleLib.utils";
 import { randomBytes } from "crypto";
-import { deployMockSpokePoolCaller } from "../fixtures/SpokePool.Fixture";
+import { deployMockSpokePoolCaller, deployMockUSSSpokePoolCaller } from "../fixtures/SpokePool.Fixture";
 
 let hubPool: Contract, polygonSpokePool: Contract, dai: Contract, weth: Contract, l2Dai: string;
 let polygonRegistry: FakeContract, erc20Predicate: FakeContract;
@@ -255,14 +255,15 @@ describe("Polygon Spoke Pool", function () {
     ]);
 
     await polygonSpokePool.connect(fxChild).processMessageFromRoot(0, owner.address, relayRootBundleData);
-    const nonEOACaller = await deployMockSpokePoolCaller(polygonSpokePool);
+
+    // Deploying  mock caller tries to execute leaf from within constructor:
     await expect(
-      nonEOACaller.connect(relayer).executeUSSRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]))
-    ).to.revertedWith("NotEOA");
+      deployMockUSSSpokePoolCaller(polygonSpokePool, 0, leaves[0], tree.getHexProof(leaves[0]))
+    ).to.be.revertedWith("NotEOA");
 
     // Executing leaf with amountToReturn == 0 is fine through contract caller.
-    await expect(nonEOACaller.connect(relayer).executeUSSRelayerRefundLeaf(0, leaves[1], tree.getHexProof(leaves[1])))
-      .to.not.be.reverted;
+    await expect(deployMockUSSSpokePoolCaller(polygonSpokePool, 0, leaves[1], tree.getHexProof(leaves[1]))).to.not.be
+      .reverted;
   });
 
   it("Must be EOA to execute relayer refund leaf with amountToReturn > 0", async function () {
@@ -282,14 +283,15 @@ describe("Polygon Spoke Pool", function () {
       mockTreeRoot,
     ]);
     await polygonSpokePool.connect(fxChild).processMessageFromRoot(0, owner.address, relayRootBundleData);
-    const nonEOACaller = await deployMockSpokePoolCaller(polygonSpokePool);
+
+    // Deploying  mock caller tries to execute leaf from within constructor:
     await expect(
-      nonEOACaller.connect(relayer).executeRelayerRefundLeaf(0, leaves[0], tree.getHexProof(leaves[0]))
-    ).to.revertedWith("NotEOA");
+      deployMockSpokePoolCaller(polygonSpokePool, 0, leaves[0], tree.getHexProof(leaves[0]))
+    ).to.be.revertedWith("NotEOA");
 
     // Executing leaf with amountToReturn == 0 is fine through contract caller.
-    await expect(nonEOACaller.connect(relayer).executeRelayerRefundLeaf(0, leaves[1], tree.getHexProof(leaves[1]))).to
-      .not.be.reverted;
+    await expect(deployMockSpokePoolCaller(polygonSpokePool, 0, leaves[1], tree.getHexProof(leaves[1]))).to.not.be
+      .reverted;
   });
 
   it("PolygonTokenBridger retrieves and unwraps tokens correctly", async function () {

--- a/test/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -239,7 +239,7 @@ describe("Polygon Spoke Pool", function () {
     const l2ChainId = await owner.getChainId();
     const leaves = buildUSSRelayerRefundLeaves(
       [l2ChainId, l2ChainId], // Destination chain ID.
-      [amountToReturn, 0], // amountToReturn.
+      [amountToReturn, ethers.constants.Zero], // amountToReturn.
       [dai.address, dai.address], // l2Token.
       [[], []], // refundAddresses.
       [[], []], // refundAmounts.
@@ -269,7 +269,7 @@ describe("Polygon Spoke Pool", function () {
     const l2ChainId = await owner.getChainId();
     const leaves = buildRelayerRefundLeaves(
       [l2ChainId, l2ChainId], // Destination chain ID.
-      [amountToReturn, 0], // amountToReturn.
+      [amountToReturn, ethers.constants.Zero], // amountToReturn.
       [dai.address, dai.address], // l2Token.
       [[], []], // refundAddresses.
       [[], []] // refundAmounts.

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -414,7 +414,7 @@ export async function deployMockSpokePoolCaller(
   spokePool: Contract,
   rootBundleId: number,
   leaf: RelayerRefundLeaf,
-  proof: string
+  proof: string[]
 ): Promise<Contract> {
   return await (
     await getContractFactory("MockCaller", (await ethers.getSigners())[0])
@@ -425,7 +425,7 @@ export async function deployMockUSSSpokePoolCaller(
   spokePool: Contract,
   rootBundleId: number,
   leaf: USSRelayerRefundLeaf,
-  proof: string
+  proof: string[]
 ): Promise<Contract> {
   return await (
     await getContractFactory("MockUSSCaller", (await ethers.getSigners())[0])

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -10,6 +10,7 @@ import {
 } from "../../utils/utils";
 
 import * as consts from "../constants";
+import { RelayerRefundLeaf, USSRelayerRefundLeaf } from "../MerkleLib.utils";
 
 export const spokePoolFixture = hre.deployments.createFixture(async ({ ethers }) => {
   return await deploySpokePool(ethers);
@@ -409,6 +410,24 @@ export async function modifyRelayHelper(
   };
 }
 
-export async function deployMockSpokePoolCaller(spokePool: Contract): Promise<Contract> {
-  return await (await getContractFactory("MockCaller", (await ethers.getSigners())[0])).deploy(spokePool.address);
+export async function deployMockSpokePoolCaller(
+  spokePool: Contract,
+  rootBundleId: number,
+  leaf: RelayerRefundLeaf,
+  proof: string
+): Promise<Contract> {
+  return await (
+    await getContractFactory("MockCaller", (await ethers.getSigners())[0])
+  ).deploy(spokePool.address, rootBundleId, leaf, proof);
+}
+
+export async function deployMockUSSSpokePoolCaller(
+  spokePool: Contract,
+  rootBundleId: number,
+  leaf: USSRelayerRefundLeaf,
+  proof: string
+): Promise<Contract> {
+  return await (
+    await getContractFactory("MockUSSCaller", (await ethers.getSigners())[0])
+  ).deploy(spokePool.address, rootBundleId, leaf, proof);
 }

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -211,6 +211,11 @@ export interface SlowFill {
   payoutAdjustmentPct: BigNumber;
 }
 
+export interface USSSlowFill {
+  relayData: USSRelayData;
+  updatedOutputAmount: BigNumber;
+}
+
 export function getRelayHash(
   _depositor: string,
   _recipient: string,
@@ -402,4 +407,8 @@ export async function modifyRelayHelper(
   return {
     signature,
   };
+}
+
+export async function deployMockSpokePoolCaller(spokePool: Contract): Promise<Contract> {
+  return await (await getContractFactory("MockCaller", (await ethers.getSigners())[0])).deploy(spokePool.address);
 }


### PR DESCRIPTION
Useful safety feature to protect function that can send xchain messages. Also adds useful scaffolding for USS unit tests
