### PR TITLE
improve(docs): add constructor arg docs to spoke deploy scripts

### DIFF
--- a/deploy/003_deploy_optimism_spokepool.ts
+++ b/deploy/003_deploy_optimism_spokepool.ts
@@ -9,6 +9,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
+
+  // Construct this spokepool with a:
+  //    * A WETH address of the WETH address
+  //    * A depositQuoteTimeBuffer of 1 hour
+  //    * A fillDeadlineBuffer of 9 hours
   const constructorArgs = ["0x4200000000000000000000000000000000000006", 3600, 32400];
   await deployNewProxy("Optimism_SpokePool", constructorArgs, initArgs);
 };

--- a/deploy/005_deploy_arbitrum_spokepool.ts
+++ b/deploy/005_deploy_arbitrum_spokepool.ts
@@ -10,6 +10,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, L2_ADDRESS_MAP[spokeChainId].l2GatewayRouter, hubPool.address, hubPool.address];
+
+  // Construct this spokepool with a:
+  //    * A WETH address of the WETH address
+  //    * A depositQuoteTimeBuffer of 1 hour
+  //    * A fillDeadlineBuffer of 9 hours
   const constructorArgs = [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 32400];
   await deployNewProxy("Arbitrum_SpokePool", constructorArgs, initArgs);
 };

--- a/deploy/007_deploy_ethereum_spokepool.ts
+++ b/deploy/007_deploy_ethereum_spokepool.ts
@@ -12,6 +12,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // Initialize deposit counter to very high number of deposits to avoid duplicate deposit ID's
   // with deprecated spoke pool.
   const initArgs = [1_000_000, hubPool.address];
+
+  // Construct this spokepool with a:
+  //    * A WETH address of the WETH address
+  //    * A depositQuoteTimeBuffer of 1 hour
+  //    * A fillDeadlineBuffer of 9 hours
   const constructorArgs = [L1_ADDRESS_MAP[chainId].weth, 3600, 32400];
   await deployNewProxy("Ethereum_SpokePool", constructorArgs, initArgs);
 

--- a/deploy/011_deploy_polygon_spokepool.ts
+++ b/deploy/011_deploy_polygon_spokepool.ts
@@ -18,6 +18,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     hubPool.address,
     L2_ADDRESS_MAP[spokeChainId].fxChild,
   ];
+
+  // Construct this spokepool with a:
+  //    * A WETH address of the WETH address
+  //    * A depositQuoteTimeBuffer of 1 hour
+  //    * A fillDeadlineBuffer of 9 hours
   const constructorArgs = [L2_ADDRESS_MAP[spokeChainId].wMatic, 3600, 32400];
   await deployNewProxy("Polygon_SpokePool", constructorArgs, initArgs);
 };

--- a/deploy/013_deploy_boba_spokepool.ts
+++ b/deploy/013_deploy_boba_spokepool.ts
@@ -9,6 +9,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
+
+  // Construct this spokepool with a:
+  //    * A WETH address of the WETH address
+  //    * A depositQuoteTimeBuffer of 1 hour
+  //    * A fillDeadlineBuffer of 9 hours
   const constructorArgs = ["0xDeadDeAddeAddEAddeadDEaDDEAdDeaDDeAD0000", 3600, 32400];
   await deployNewProxy("Boba_SpokePool", constructorArgs, initArgs);
 };

--- a/deploy/016_deploy_zksync_spokepool.ts
+++ b/deploy/016_deploy_zksync_spokepool.ts
@@ -23,11 +23,16 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
     hubPool.address,
     hubPool.address,
   ];
+  // Construct this spokepool with a:
+  //    * A WETH address of the WETH address
+  //    * A depositQuoteTimeBuffer of 1 hour
+  //    * A fillDeadlineBuffer of 9 hours
+  const constructorArgs = [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 32400];
 
   const proxy = await zkUpgrades.deployProxy(deployer.zkWallet, artifact, initArgs, {
     initializer: "initialize",
     kind: "uups",
-    constructorArgs: [L2_ADDRESS_MAP[spokeChainId].l2Weth, 3600, 32400],
+    constructorArgs,
     unsafeAllow: ["delegatecall"], // Remove after upgrading openzeppelin-contracts-upgradeable post v4.9.3.
   });
   console.log(`Deployment transaction hash: ${proxy.deployTransaction.hash}.`);

--- a/deploy/025_deploy_base_spokepool.ts
+++ b/deploy/025_deploy_base_spokepool.ts
@@ -9,6 +9,11 @@ const func: DeployFunction = async function (hre: HardhatRuntimeEnvironment) {
   // with deprecated spoke pool.
   // Set hub pool as cross domain admin since it delegatecalls the Adapter logic.
   const initArgs = [1_000_000, hubPool.address, hubPool.address];
+
+  // Construct this spokepool with a:
+  //    * A WETH address of the WETH address
+  //    * A depositQuoteTimeBuffer of 1 hour
+  //    * A fillDeadlineBuffer of 9 hours
   const constructorArgs = ["0x4200000000000000000000000000000000000006", 3600, 32400];
   await deployNewProxy("Base_SpokePool", constructorArgs, initArgs);
 };


### PR DESCRIPTION
Spurred by this comment:  https://github.com/across-protocol/contracts-v2/pull/381#discussion_r1437706052 We should comment on all of our spoke deployments.

Alternate option: we immortalize these args in a constant because they're identical across our deploy scripts.