### PR TITLE
fix(SpokePool): Address speedup USS depositor signature logic and add unit tests

### DIFF
--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -183,8 +183,8 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
 
     function executeUSSRelayerRefundLeaf(
         uint32 rootBundleId,
-        USSRelayerRefundLeaf memory relayerRefundLeaf,
-        bytes32[] memory proof
+        USSRelayerRefundLeaf calldata relayerRefundLeaf,
+        bytes32[] calldata proof
     ) public override {
         // AddressLibUpgradeable.isContract isn't a sufficient check because it checks the contract code size of
         // msg.sender which is 0 if called from a constructor function on msg.sender. This is why we check if

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -659,7 +659,7 @@ abstract contract SpokePool is
         uint32 quoteTimestamp,
         uint32 fillDeadline,
         uint32 exclusivityDeadline,
-        bytes memory message
+        bytes calldata message
     ) public payable override nonReentrant unpausedDeposits {
         // Check that deposit route is enabled for the input token. There are no checks required for the output token
         // which is pulled from the relayer at fill time and passed through this contract atomically to the recipient.
@@ -717,8 +717,8 @@ abstract contract SpokePool is
         uint32 depositId,
         uint256 updatedOutputAmount,
         address updatedRecipient,
-        bytes memory updatedMessage,
-        bytes memory depositorSignature
+        bytes calldata updatedMessage,
+        bytes calldata depositorSignature
     ) public override nonReentrant {
         _verifyUpdateUSSDepositMessage(
             depositor,
@@ -912,7 +912,7 @@ abstract contract SpokePool is
      *         USS RELAYER FUNCTIONS          *
      ******************************************/
 
-    function fillUSSRelay(USSRelayData memory relayData, uint256 repaymentChainId)
+    function fillUSSRelay(USSRelayData calldata relayData, uint256 repaymentChainId)
         public
         override
         nonReentrant
@@ -943,12 +943,12 @@ abstract contract SpokePool is
     }
 
     function fillUSSRelayWithUpdatedDeposit(
-        USSRelayData memory relayData,
+        USSRelayData calldata relayData,
         uint256 repaymentChainId,
         uint256 updatedOutputAmount,
         address updatedRecipient,
-        bytes memory updatedMessage,
-        bytes memory depositorSignature
+        bytes calldata updatedMessage,
+        bytes calldata depositorSignature
     ) public override nonReentrant unpausedFills {
         // Exclusivity deadline is inclusive and is the latest timestamp that the exclusive relayer has sole right
         // to fill the relay.
@@ -993,7 +993,7 @@ abstract contract SpokePool is
      * slow filled. If any of the params are missing or different then Across will not include a slow
      * fill for the intended deposit.
      */
-    function requestUSSSlowFill(USSRelayData memory relayData) public override nonReentrant unpausedFills {
+    function requestUSSSlowFill(USSRelayData calldata relayData) public override nonReentrant unpausedFills {
         // solhint-disable-next-line not-rely-on-time
         if (relayData.fillDeadline < block.timestamp) revert ExpiredFillDeadline();
 
@@ -1077,9 +1077,9 @@ abstract contract SpokePool is
     // @dev We pack the function params into USSSlowFill to avoid stack-to-deep error that occurs
     // when a function is called with more than 13 params.
     function executeUSSSlowRelayLeaf(
-        USSSlowFill memory slowFillLeaf,
+        USSSlowFill calldata slowFillLeaf,
         uint32 rootBundleId,
-        bytes32[] memory proof
+        bytes32[] calldata proof
     ) public override nonReentrant {
         USSRelayData memory relayData = slowFillLeaf.relayData;
 
@@ -1168,8 +1168,8 @@ abstract contract SpokePool is
      */
     function executeUSSRelayerRefundLeaf(
         uint32 rootBundleId,
-        USSSpokePoolInterface.USSRelayerRefundLeaf memory relayerRefundLeaf,
-        bytes32[] memory proof
+        USSSpokePoolInterface.USSRelayerRefundLeaf calldata relayerRefundLeaf,
+        bytes32[] calldata proof
     ) public virtual override nonReentrant {
         _preExecuteLeafHook(relayerRefundLeaf.l2TokenAddress);
 

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -152,6 +152,10 @@ abstract contract SpokePool is
             "UpdateDepositDetails(uint32 depositId,uint256 originChainId,int64 updatedRelayerFeePct,address updatedRecipient,bytes updatedMessage)"
         );
 
+    bytes32 public constant UPDATE_USS_DEPOSIT_DETAILS_HASH =
+        keccak256(
+            "UpdateDepositDetails(uint32 depositId,uint256 originChainId,uint256 updatedOutputAmount,address updatedRecipient,bytes updatedMessage)"
+        );
     /****************************************
      *                EVENTS                *
      ****************************************/
@@ -1462,7 +1466,7 @@ abstract contract SpokePool is
             // EIP-712 compliant hash struct: https://eips.ethereum.org/EIPS/eip-712#definition-of-hashstruct
             keccak256(
                 abi.encode(
-                    UPDATE_DEPOSIT_DETAILS_HASH,
+                    UPDATE_USS_DEPOSIT_DETAILS_HASH,
                     depositId,
                     originChainId,
                     updatedOutputAmount,

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -928,7 +928,7 @@ abstract contract SpokePool is
         // Don't let caller override destination chain ID so they can't attempt a replay attack of an identical
         // fill that was destined for a different chain. This is required because the relayData
         // is used to form the relayHash which this contract uses to uniquely ID relays.
-        relayData.destinationChainId = chainId();
+        if (relayData.destinationChainId != chainId()) revert InvalidChainId();
 
         USSRelayExecutionParams memory relayExecution = USSRelayExecutionParams({
             relay: relayData,
@@ -960,7 +960,7 @@ abstract contract SpokePool is
         // Don't let caller override destination chain ID so they can't attempt a replay attack of an identical
         // fill that was destined for a different chain. This is required because the relayData
         // is used to form the relayHash which this contract uses to uniquely ID relays.
-        relayData.destinationChainId = chainId();
+        if (relayData.destinationChainId != chainId()) revert InvalidChainId();
 
         USSRelayExecutionParams memory relayExecution = USSRelayExecutionParams({
             relay: relayData,
@@ -1088,7 +1088,7 @@ abstract contract SpokePool is
         // Don't let caller override destination chain ID so they can't attempt a replay attack of an identical
         // fill that was destined for a different chain. This is required because the relayData
         // is used to form the relayHash which this contract uses to uniquely ID relays.
-        relayData.destinationChainId = chainId();
+        if (relayData.destinationChainId != chainId()) revert InvalidChainId();
 
         // @TODO In the future consider allowing way for slow fill leaf to be created with updated
         // deposit params like outputAmount, message and recipient.

--- a/contracts/interfaces/USSSpokePoolInterface.sol
+++ b/contracts/interfaces/USSSpokePoolInterface.sol
@@ -191,22 +191,22 @@ interface USSSpokePoolInterface {
         uint32 depositId,
         uint256 updatedOutputAmount,
         address updatedRecipient,
-        bytes memory updatedMessage,
-        bytes memory depositorSignature
+        bytes calldata updatedMessage,
+        bytes calldata depositorSignature
     ) external;
 
-    function fillUSSRelay(USSRelayData memory relayData, uint256 repaymentChainId) external;
+    function fillUSSRelay(USSRelayData calldata relayData, uint256 repaymentChainId) external;
 
     function fillUSSRelayWithUpdatedDeposit(
-        USSRelayData memory relayData,
+        USSRelayData calldata relayData,
         uint256 repaymentChainId,
         uint256 updatedOutputAmount,
         address updatedRecipient,
-        bytes memory updatedMessage,
-        bytes memory depositorSignature
+        bytes calldata updatedMessage,
+        bytes calldata depositorSignature
     ) external;
 
-    function requestUSSSlowFill(USSRelayData memory relayData) external;
+    function requestUSSSlowFill(USSRelayData calldata relayData) external;
 
     function executeUSSSlowRelayLeaf(
         USSSlowFill calldata slowFillLeaf,
@@ -216,8 +216,8 @@ interface USSSpokePoolInterface {
 
     function executeUSSRelayerRefundLeaf(
         uint32 rootBundleId,
-        USSRelayerRefundLeaf memory relayerRefundLeaf,
-        bytes32[] memory proof
+        USSRelayerRefundLeaf calldata relayerRefundLeaf,
+        bytes32[] calldata proof
     ) external;
 
     error DisabledRoute();

--- a/contracts/test/AcrossMessageHandlerMock.sol
+++ b/contracts/test/AcrossMessageHandlerMock.sol
@@ -2,6 +2,8 @@
 pragma solidity ^0.8.0;
 
 import "../SpokePool.sol";
+import "../interfaces/USSSpokePoolInterface.sol";
+import "hardhat/console.sol";
 
 contract AcrossMessageHandlerMock is AcrossMessageHandler {
     function handleAcrossMessage(
@@ -18,4 +20,19 @@ contract AcrossMessageHandlerMock is AcrossMessageHandler {
         address relayer,
         bytes memory message
     ) external override {}
+}
+
+contract AcrossMessageHandlerCallbackMock {
+    function handleUSSAcrossMessage(
+        address,
+        uint256,
+        address,
+        bytes memory message
+    ) external {
+        // Callback into SpokePool; designed to be used to test for reentrancy protection
+        // on public functions
+        // solhint-disable-next-line avoid-low-level-calls
+        (bool success, bytes memory returnData) = msg.sender.call(message);
+        require(success, string(returnData));
+    }
 }

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -40,6 +40,27 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
         _distributeRelayerRefunds(_chainId, amountToReturn, refundAmounts, leafId, l2TokenAddress, refundAddresses);
     }
 
+    function verifyUpdateUSSDepositMessage(
+        address depositor,
+        uint32 depositId,
+        uint256 originChainId,
+        uint256 updatedOutputAmount,
+        address updatedRecipient,
+        bytes memory updatedMessage,
+        bytes memory depositorSignature
+    ) public view {
+        return
+            _verifyUpdateUSSDepositMessage(
+                depositor,
+                depositId,
+                originChainId,
+                updatedOutputAmount,
+                updatedRecipient,
+                updatedMessage,
+                depositorSignature
+            );
+    }
+
     function fillRelayUSSInternal(
         USSRelayExecutionParams memory relayExecution,
         address relayer,

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -40,6 +40,18 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
         _distributeRelayerRefunds(_chainId, amountToReturn, refundAmounts, leafId, l2TokenAddress, refundAddresses);
     }
 
+    function fillRelayUSSInternal(
+        USSRelayExecutionParams memory relayExecution,
+        address relayer,
+        bool isSlowFill
+    ) external {
+        _fillRelayUSS(relayExecution, relayer, isSlowFill);
+    }
+
+    function setFillStatus(bytes32 relayHash, FillType fillType) external {
+        fillStatuses[relayHash] = uint256(fillType);
+    }
+
     function getCurrentTime() public view override returns (uint256) {
         return currentTime;
     }

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -465,7 +465,7 @@ describe("SpokePool Depositor Logic", async function () {
       await expect(
         spokePool.connect(depositor).depositUSS(
           // quoteTimestamp too far into past (i.e. beyond the buffer)
-          ...getDepositArgsFromRelayData(relayData, currentTime.sub(quoteTimeBuffer).sub(100))
+          ...getDepositArgsFromRelayData(relayData, currentTime.sub(quoteTimeBuffer).sub(1))
         )
       ).to.be.revertedWith("InvalidQuoteTimestamp");
       await expect(

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -482,7 +482,7 @@ describe("SpokePool Depositor Logic", async function () {
       await expect(
         spokePool.connect(depositor).depositUSS(
           // fillDeadline too far into future (i.e. beyond the buffer)
-          ...getDepositArgsFromRelayData({ ...relayData, fillDeadline: currentTime.add(fillDeadlineBuffer).add(100) })
+          ...getDepositArgsFromRelayData({ ...relayData, fillDeadline: currentTime.add(fillDeadlineBuffer).add(1) })
         )
       ).to.be.revertedWith("InvalidFillDeadline");
       await expect(

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -498,7 +498,6 @@ describe("SpokePool Relayer Logic", async function () {
               relayExecution.updatedRecipient,
               relayExecution.updatedMessage,
               relayExecution.updatedOutputAmount,
-              // Testing that this FillType is "SlowFill"
               FillType.FastFill,
             ]
           );

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -538,7 +538,7 @@ describe("SpokePool Relayer Logic", async function () {
           )
         ).to.changeTokenBalance(destErc20, depositor, consts.amountToDeposit.mul(2));
       });
-      it("unwraps native token if sending to EOA otherwise sends wrapped ERC20", async function () {
+      it("unwraps native token if sending to EOA", async function () {
         const _relayData = {
           ...relayData,
           outputToken: weth.address,

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -559,6 +559,7 @@ describe("SpokePool Relayer Logic", async function () {
         };
         const relayExecution = await getRelayExecutionParams(_relayData);
         await weth.connect(relayer).transfer(spokePool.address, relayExecution.updatedOutputAmount);
+        const initialSpokeBalance = await weth.balanceOf(spokePool.address);
         await expect(() =>
           spokePool.connect(relayer).fillRelayUSSInternal(
             relayExecution,
@@ -566,6 +567,8 @@ describe("SpokePool Relayer Logic", async function () {
             true // isSlowFill
           )
         ).to.changeEtherBalance(recipient, relayExecution.updatedOutputAmount);
+        const spokeBalance = await weth.balanceOf(spokePool.address);
+        expect(spokeBalance).to.equal(initialSpokeBalance.sub(relayExecution.updatedOutputAmount));
       });
       it("slow fills send non-native token out of spoke pool balance", async function () {
         const relayExecution = await getRelayExecutionParams(relayData);
@@ -654,14 +657,9 @@ describe("SpokePool Relayer Logic", async function () {
           // Try to overwrite the passed in destinationChainId
           destinationChainId: consts.originChainId,
         };
-        await spokePool.connect(relayer).fillUSSRelay(_relayData, consts.repaymentChainId);
-
-        // Check that relay hash was filled with the correct destination chain ID from the
-        // original relay data, not the overwritten one.
-        const { relayHash } = await getRelayExecutionParams(relayData);
-        expect(await spokePool.fillStatuses(relayHash)).to.equal(FillStatus.Filled);
-        const { relayHash: invalidRelayHash } = await getRelayExecutionParams(_relayData);
-        expect(await spokePool.fillStatuses(invalidRelayHash)).to.equal(FillStatus.Unfilled);
+        await expect(spokePool.connect(relayer).fillUSSRelay(_relayData, consts.repaymentChainId)).to.revertedWith(
+          "InvalidChainId"
+        );
       });
       it("calls _fillRelayUSS with  expected params", async function () {
         await expect(spokePool.connect(relayer).fillUSSRelay(relayData, consts.repaymentChainId))

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -424,3 +424,37 @@ export async function modifyRelayHelper(
     signature,
   };
 }
+
+export async function getUpdatedUSSDepositSignature(
+  depositor: SignerWithAddress,
+  depositId: number,
+  originChainId: number,
+  updatedOutputAmount: BigNumber,
+  updatedRecipient: string,
+  updatedMessage: string
+): Promise<{ signature: string }> {
+  const typedData = {
+    types: {
+      UpdateDepositDetails: [
+        { name: "depositId", type: "uint32" },
+        { name: "originChainId", type: "uint256" },
+        { name: "updatedOutputAmount", type: "uint256" },
+        { name: "updatedRecipient", type: "address" },
+        { name: "updatedMessage", type: "bytes" },
+      ],
+    },
+    domain: {
+      name: "ACROSS-V2",
+      version: "1.0.0",
+      chainId: Number(originChainId),
+    },
+    message: {
+      depositId,
+      originChainId,
+      updatedOutputAmount,
+      updatedRecipient,
+      updatedMessage,
+    },
+  };
+  return await depositor._signTypedData(typedData.domain, typedData.types, typedData.message);
+}

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -206,6 +206,27 @@ export interface USSRelayData {
   message: string;
 }
 
+export interface USSRelayExecutionParams {
+  relay: USSRelayData;
+  relayHash: string;
+  updatedOutputAmount: BigNumber;
+  updatedRecipient: string;
+  updatedMessage: string;
+  repaymentChainId: number;
+}
+
+export const enum FillType {
+  FastFill,
+  ReplacedSlowFill,
+  SlowFill,
+}
+
+export const enum FillStatus {
+  Unfilled,
+  RequestedSlowFill,
+  Filled,
+}
+
 export interface SlowFill {
   relayData: RelayData;
   payoutAdjustmentPct: BigNumber;

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -452,7 +452,7 @@ export async function getUpdatedUSSDepositSignature(
     domain: {
       name: "ACROSS-V2",
       version: "1.0.0",
-      chainId: Number(originChainId),
+      chainId: originChainId,
     },
     message: {
       depositId,

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -438,7 +438,7 @@ export async function getUpdatedUSSDepositSignature(
   updatedOutputAmount: BigNumber,
   updatedRecipient: string,
   updatedMessage: string
-): Promise<{ signature: string }> {
+): Promise<string> {
   const typedData = {
     types: {
       UpdateDepositDetails: [


### PR DESCRIPTION
Fixes bug in _verifyUpdateUSSDepositMessage where the incorrect type string is used (i.e. it still includes int64 updatedRelayerFeePct instead of uint256 updatedOutputAmount) which means that the depositor 
signature will never match the passed in "speed up params".

This PR also adds unit tests for both `depositUSS` and `speedUpUSSDeposit`.

