### PR TITLE
improve(SpokePool): Replace block.timestamp with getCurrentTIme()

### DIFF
--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -244,15 +244,15 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool {
     }
 
     function _setFunctionLock(bytes32 funcIdentifier) internal {
-        // solhint-disable-next-line not-rely-on-time, avoid-tx-origin
-        bytes32 lockValue = keccak256(abi.encodePacked(block.timestamp, tx.origin));
+        // solhint-disable-next-line avoid-tx-origin
+        bytes32 lockValue = keccak256(abi.encodePacked(getCurrentTime(), tx.origin));
         if (funcLocks[funcIdentifier] != lockValue) funcLocks[funcIdentifier] = lockValue;
     }
 
     // Revert if function was called during this block with the same tx.origin.
     function _revertIfFunctionCalledAtomically(bytes32 funcIdentifier) internal view {
-        // solhint-disable-next-line not-rely-on-time, avoid-tx-origin
-        if (funcLocks[funcIdentifier] == keccak256(abi.encodePacked(block.timestamp, tx.origin)))
+        // solhint-disable-next-line avoid-tx-origin
+        if (funcLocks[funcIdentifier] == keccak256(abi.encodePacked(getCurrentTime(), tx.origin)))
             revert CrossFunctionLock();
     }
 

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -916,8 +916,7 @@ abstract contract SpokePool is
     {
         // Exclusivity deadline is inclusive and is the latest timestamp that the exclusive relayer has sole right
         // to fill the relay.
-        // solhint-disable-next-line not-rely-on-time
-        if (relayData.exclusiveRelayer != msg.sender && relayData.exclusivityDeadline >= block.timestamp) {
+        if (relayData.exclusiveRelayer != msg.sender && relayData.exclusivityDeadline >= getCurrentTime()) {
             revert NotExclusiveRelayer();
         }
 
@@ -948,8 +947,7 @@ abstract contract SpokePool is
     ) public override nonReentrant unpausedFills {
         // Exclusivity deadline is inclusive and is the latest timestamp that the exclusive relayer has sole right
         // to fill the relay.
-        // solhint-disable-next-line not-rely-on-time
-        if (relayData.exclusiveRelayer != msg.sender && relayData.exclusivityDeadline >= block.timestamp) {
+        if (relayData.exclusiveRelayer != msg.sender && relayData.exclusivityDeadline >= getCurrentTime()) {
             revert NotExclusiveRelayer();
         }
 
@@ -990,8 +988,7 @@ abstract contract SpokePool is
      * fill for the intended deposit.
      */
     function requestUSSSlowFill(USSRelayData memory relayData) public override nonReentrant unpausedFills {
-        // solhint-disable-next-line not-rely-on-time
-        if (relayData.fillDeadline < block.timestamp) revert ExpiredFillDeadline();
+        if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();
 
         bytes32 relayHash = keccak256(abi.encode(relayData));
         if (fillStatuses[relayHash] != uint256(FillStatus.Unfilled)) revert InvalidSlowFillRequest();
@@ -1699,8 +1696,7 @@ abstract contract SpokePool is
     ) internal {
         USSRelayData memory relayData = relayExecution.relay;
 
-        // solhint-disable-next-line not-rely-on-time
-        if (relayData.fillDeadline < block.timestamp) revert ExpiredFillDeadline();
+        if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();
 
         bytes32 relayHash = relayExecution.relayHash;
 


### PR DESCRIPTION
Originally I used block.timestamp in new USS functions in order to avoid a potential JUMP opcode when calling `getCurrentTime()` however @pxrl astutely pointed out that downstream tests like those in `relayer-v2` manipulate time via `MockSpokePool.setCurrentTime()` in unit tests so using `block.timestamp` might make it harder for these unit tests to pass when modified to address the USS functions
