### PR TITLE
improve(SpokePool): Remove `destinationChainId` from USSRelayData struct

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -91,7 +91,7 @@ abstract contract SpokePool is
     mapping(bytes32 => uint256) private DEPRECATED_relayFills;
 
     // Mapping of USS relay hashes to fill statuses. Distinguished from relayFills
-    // to eliminate any chance of collision between RelayData hashes and USSRelayData hashes.
+    // to eliminate any chance of collision between pre and post USS relay hashes.
     mapping(bytes32 => uint256) public fillStatuses;
 
     // Note: We will likely un-deprecate the fill and deposit counters to implement a better
@@ -912,7 +912,7 @@ abstract contract SpokePool is
      *         USS RELAYER FUNCTIONS          *
      ******************************************/
 
-    function fillUSSRelay(DepositData calldata relayData, uint256 repaymentChainId)
+    function fillUSSRelay(USSRelayData calldata relayData, uint256 repaymentChainId)
         public
         override
         nonReentrant
@@ -937,7 +937,7 @@ abstract contract SpokePool is
     }
 
     function fillUSSRelayWithUpdatedDeposit(
-        DepositData calldata relayData,
+        USSRelayData calldata relayData,
         uint256 repaymentChainId,
         uint256 updatedOutputAmount,
         address updatedRecipient,
@@ -977,11 +977,11 @@ abstract contract SpokePool is
      * for a deposit in the next bundle.
      * @dev Slow fills are not possible unless the input and output tokens are "equivalent", i.e.
      * they route to the same L1 token via PoolRebalanceRoutes.
-     * @param relayData USSRelayData struct containing all the data needed to identify the deposit that should be
+     * @param relayData struct containing all the data needed to identify the deposit that should be
      * slow filled. If any of the params are missing or different then Across will not include a slow
      * fill for the intended deposit.
      */
-    function requestUSSSlowFill(DepositData calldata relayData) public override nonReentrant unpausedFills {
+    function requestUSSSlowFill(USSRelayData calldata relayData) public override nonReentrant unpausedFills {
         if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();
 
         bytes32 relayHash = keccak256(abi.encode(relayData, chainId()));
@@ -1068,7 +1068,7 @@ abstract contract SpokePool is
         uint32 rootBundleId,
         bytes32[] calldata proof
     ) public override nonReentrant {
-        DepositData memory relayData = slowFillLeaf.relayData;
+        USSRelayData memory relayData = slowFillLeaf.relayData;
 
         _preExecuteLeafHook(relayData.outputToken);
 
@@ -1683,7 +1683,7 @@ abstract contract SpokePool is
         address relayer,
         bool isSlowFill
     ) internal {
-        DepositData memory relayData = relayExecution.relay;
+        USSRelayData memory relayData = relayExecution.relay;
 
         if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();
 

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -927,7 +927,7 @@ abstract contract SpokePool is
 
         USSRelayExecutionParams memory relayExecution = USSRelayExecutionParams({
             relay: relayData,
-            relayHash: _getUSSRelayHash(relayData),
+            relayHash: keccak256(abi.encode(relayData, chainId())),
             updatedOutputAmount: relayData.outputAmount,
             updatedRecipient: relayData.recipient,
             updatedMessage: relayData.message,
@@ -954,7 +954,7 @@ abstract contract SpokePool is
 
         USSRelayExecutionParams memory relayExecution = USSRelayExecutionParams({
             relay: relayData,
-            relayHash: _getUSSRelayHash(relayData),
+            relayHash: keccak256(abi.encode(relayData, chainId())),
             updatedOutputAmount: updatedOutputAmount,
             updatedRecipient: updatedRecipient,
             updatedMessage: updatedMessage,
@@ -987,7 +987,7 @@ abstract contract SpokePool is
         // solhint-disable-next-line not-rely-on-time
         if (relayData.fillDeadline < block.timestamp) revert ExpiredFillDeadline();
 
-        bytes32 relayHash = _getUSSRelayHash(relayData);
+        bytes32 relayHash = keccak256(abi.encode(relayData, chainId()));
         if (fillStatuses[relayHash] != uint256(FillStatus.Unfilled)) revert InvalidSlowFillRequest();
         fillStatuses[relayHash] = uint256(FillStatus.RequestedSlowFill);
 
@@ -1079,7 +1079,7 @@ abstract contract SpokePool is
         // deposit params like outputAmount, message and recipient.
         USSRelayExecutionParams memory relayExecution = USSRelayExecutionParams({
             relay: relayData,
-            relayHash: _getUSSRelayHash(relayData),
+            relayHash: keccak256(abi.encode(relayData, chainId())),
             updatedOutputAmount: slowFillLeaf.updatedOutputAmount,
             updatedRecipient: relayData.recipient,
             updatedMessage: relayData.message,
@@ -1525,10 +1525,6 @@ abstract contract SpokePool is
 
     function _getRelayHash(SpokePoolInterface.RelayData memory relayData) private pure returns (bytes32) {
         return keccak256(abi.encode(relayData));
-    }
-
-    function _getUSSRelayHash(DepositData memory relayData) private view returns (bytes32) {
-        return keccak256(abi.encode(relayData, chainId()));
     }
 
     // Unwraps ETH and does a transfer to a recipient address. If the recipient is a smart contract then sends wrappedNativeToken.

--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -926,7 +926,7 @@ abstract contract SpokePool is
 
         USSRelayExecutionParams memory relayExecution = USSRelayExecutionParams({
             relay: relayData,
-            relayHash: keccak256(abi.encode(relayData, chainId())),
+            relayHash: _getUSSRelayHash(relayData),
             updatedOutputAmount: relayData.outputAmount,
             updatedRecipient: relayData.recipient,
             updatedMessage: relayData.message,
@@ -952,7 +952,7 @@ abstract contract SpokePool is
 
         USSRelayExecutionParams memory relayExecution = USSRelayExecutionParams({
             relay: relayData,
-            relayHash: keccak256(abi.encode(relayData, chainId())),
+            relayHash: _getUSSRelayHash(relayData),
             updatedOutputAmount: updatedOutputAmount,
             updatedRecipient: updatedRecipient,
             updatedMessage: updatedMessage,
@@ -984,7 +984,7 @@ abstract contract SpokePool is
     function requestUSSSlowFill(USSRelayData calldata relayData) public override nonReentrant unpausedFills {
         if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();
 
-        bytes32 relayHash = keccak256(abi.encode(relayData, chainId()));
+        bytes32 relayHash = _getUSSRelayHash(relayData);
         if (fillStatuses[relayHash] != uint256(FillStatus.Unfilled)) revert InvalidSlowFillRequest();
         fillStatuses[relayHash] = uint256(FillStatus.RequestedSlowFill);
 
@@ -1076,7 +1076,7 @@ abstract contract SpokePool is
         // deposit params like outputAmount, message and recipient.
         USSRelayExecutionParams memory relayExecution = USSRelayExecutionParams({
             relay: relayData,
-            relayHash: keccak256(abi.encode(relayData, chainId())),
+            relayHash: _getUSSRelayHash(relayData),
             updatedOutputAmount: slowFillLeaf.updatedOutputAmount,
             updatedRecipient: relayData.recipient,
             updatedMessage: relayData.message,
@@ -1522,6 +1522,10 @@ abstract contract SpokePool is
 
     function _getRelayHash(SpokePoolInterface.RelayData memory relayData) private pure returns (bytes32) {
         return keccak256(abi.encode(relayData));
+    }
+
+    function _getUSSRelayHash(USSRelayData memory relayData) private view returns (bytes32) {
+        return keccak256(abi.encode(relayData, chainId()));
     }
 
     // Unwraps ETH and does a transfer to a recipient address. If the recipient is a smart contract then sends wrappedNativeToken.

--- a/contracts/interfaces/USSSpokePoolInterface.sol
+++ b/contracts/interfaces/USSSpokePoolInterface.sol
@@ -23,42 +23,11 @@ interface USSSpokePoolInterface {
         // the slow fill is validated.
     }
 
-    // This struct represents the data to fully specify a **unique** relay. This data is hashed and saved by the SpokePool
-    // to prevent collisions. If any portion of this data differs, the relay is considered to be completely distinct.
+    // This struct represents the data to fully specify a **unique** relay submitted on this chain.
+    // This data is hashed with the chainId() and saved by the SpokePool to prevent collisions and protect against
+    // replay attacks on other chains. If any portion of this data differs, the relay is considered to be
+    // completely distinct.
     struct USSRelayData {
-        // The address that made the deposit on the origin chain.
-        address depositor;
-        // The recipient address on the destination chain.
-        address recipient;
-        // This is the exclusive relayer who can fill the deposit before the exclusivity deadline.
-        address exclusiveRelayer;
-        // Token that is deposited on origin chain by depositor.
-        address inputToken;
-        // Token that is received on destination chain by recipient.
-        address outputToken;
-        // The amount of input token deposited by depositor.
-        uint256 inputAmount;
-        // The amount of output token to be received by recipient.
-        uint256 outputAmount;
-        // Origin chain id.
-        uint256 originChainId;
-        // Destination chain id.
-        uint256 destinationChainId;
-        // The id uniquely identifying this deposit on the origin chain.
-        uint32 depositId;
-        // The timestamp on the destination chain after which this deposit can no longer be filled.
-        uint32 fillDeadline;
-        // The timestamp on the destination chain after which any relayer can fill the deposit.
-        uint32 exclusivityDeadline;
-        // Data that is forwarded to the recipient.
-        bytes message;
-    }
-
-    // This struct is used to pack params together when calling fillUSS functions which otherwise would fail to compile
-    // because of the large number of params. It is identical to USSRelayData except that it does not contain
-    // the destinationChainId which should not be overriddable by the caller and can always be inferred by the chainId()
-    // of the SpokePool network.
-    struct DepositData {
         // The address that made the deposit on the origin chain.
         address depositor;
         // The recipient address on the destination chain.
@@ -87,7 +56,7 @@ interface USSSpokePoolInterface {
 
     // Contains parameters passed in by someone who wants to execute a slow relay leaf.
     struct USSSlowFill {
-        DepositData relayData;
+        USSRelayData relayData;
         uint256 chainId;
         uint256 updatedOutputAmount;
     }
@@ -119,7 +88,7 @@ interface USSSpokePoolInterface {
     // by the relayer to modify fields of the relay with the depositor's permission, and "repaymentChainId" is specified
     // by the relayer to determine where to take a relayer refund, but doesn't affect the uniqueness of the relay.
     struct USSRelayExecutionParams {
-        DepositData relay;
+        USSRelayData relay;
         bytes32 relayHash;
         uint256 updatedOutputAmount;
         address updatedRecipient;
@@ -228,10 +197,10 @@ interface USSSpokePoolInterface {
         bytes calldata depositorSignature
     ) external;
 
-    function fillUSSRelay(DepositData calldata relayData, uint256 repaymentChainId) external;
+    function fillUSSRelay(USSRelayData calldata relayData, uint256 repaymentChainId) external;
 
     function fillUSSRelayWithUpdatedDeposit(
-        DepositData calldata relayData,
+        USSRelayData calldata relayData,
         uint256 repaymentChainId,
         uint256 updatedOutputAmount,
         address updatedRecipient,
@@ -239,7 +208,7 @@ interface USSSpokePoolInterface {
         bytes calldata depositorSignature
     ) external;
 
-    function requestUSSSlowFill(DepositData calldata relayData) external;
+    function requestUSSSlowFill(USSRelayData calldata relayData) external;
 
     function executeUSSSlowRelayLeaf(
         USSSlowFill calldata slowFillLeaf,

--- a/contracts/interfaces/USSSpokePoolInterface.sol
+++ b/contracts/interfaces/USSSpokePoolInterface.sol
@@ -54,8 +54,41 @@ interface USSSpokePoolInterface {
         bytes message;
     }
 
+    // This struct is used to pack params together when calling fillUSS functions which otherwise would fail to compile
+    // because of the large number of params. It is identical to USSRelayData except that it does not contain
+    // the destinationChainId which should not be overriddable by the caller and can always be inferred by the chainId()
+    // of the SpokePool network.
+    struct DepositData {
+        // The address that made the deposit on the origin chain.
+        address depositor;
+        // The recipient address on the destination chain.
+        address recipient;
+        // This is the exclusive relayer who can fill the deposit before the exclusivity deadline.
+        address exclusiveRelayer;
+        // Token that is deposited on origin chain by depositor.
+        address inputToken;
+        // Token that is received on destination chain by recipient.
+        address outputToken;
+        // The amount of input token deposited by depositor.
+        uint256 inputAmount;
+        // The amount of output token to be received by recipient.
+        uint256 outputAmount;
+        // Origin chain id.
+        uint256 originChainId;
+        // The id uniquely identifying this deposit on the origin chain.
+        uint32 depositId;
+        // The timestamp on the destination chain after which this deposit can no longer be filled.
+        uint32 fillDeadline;
+        // The timestamp on the destination chain after which any relayer can fill the deposit.
+        uint32 exclusivityDeadline;
+        // Data that is forwarded to the recipient.
+        bytes message;
+    }
+
+    // Contains parameters passed in by someone who wants to execute a slow relay leaf.
     struct USSSlowFill {
-        USSRelayData relayData;
+        DepositData relayData;
+        uint256 chainId;
         uint256 updatedOutputAmount;
     }
 
@@ -86,7 +119,7 @@ interface USSSpokePoolInterface {
     // by the relayer to modify fields of the relay with the depositor's permission, and "repaymentChainId" is specified
     // by the relayer to determine where to take a relayer refund, but doesn't affect the uniqueness of the relay.
     struct USSRelayExecutionParams {
-        USSRelayData relay;
+        DepositData relay;
         bytes32 relayHash;
         uint256 updatedOutputAmount;
         address updatedRecipient;
@@ -195,10 +228,10 @@ interface USSSpokePoolInterface {
         bytes calldata depositorSignature
     ) external;
 
-    function fillUSSRelay(USSRelayData calldata relayData, uint256 repaymentChainId) external;
+    function fillUSSRelay(DepositData calldata relayData, uint256 repaymentChainId) external;
 
     function fillUSSRelayWithUpdatedDeposit(
-        USSRelayData calldata relayData,
+        DepositData calldata relayData,
         uint256 repaymentChainId,
         uint256 updatedOutputAmount,
         address updatedRecipient,
@@ -206,7 +239,7 @@ interface USSSpokePoolInterface {
         bytes calldata depositorSignature
     ) external;
 
-    function requestUSSSlowFill(USSRelayData calldata relayData) external;
+    function requestUSSSlowFill(DepositData calldata relayData) external;
 
     function executeUSSSlowRelayLeaf(
         USSSlowFill calldata slowFillLeaf,

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -69,6 +69,13 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
         _fillRelayUSS(relayExecution, relayer, isSlowFill);
     }
 
+    // This function is nonReentrant in order to allow caller to test whether a different function
+    // is reentrancy protected or not.
+    function callback(bytes memory data) external payable nonReentrant {
+        (bool success, bytes memory result) = address(this).call{ value: msg.value }(data);
+        require(success, string(result));
+    }
+
     function setFillStatus(bytes32 relayHash, FillType fillType) external {
         fillStatuses[relayHash] = uint256(fillType);
     }

--- a/test/MerkleLib.Proofs.ts
+++ b/test/MerkleLib.Proofs.ts
@@ -13,7 +13,7 @@ import {
   createRandomBytes32,
   ethers,
 } from "../utils/utils";
-import { USSRelayData, USSSlowFill } from "../test-utils";
+import { USSFillDepositData, USSRelayData, USSSlowFill } from "../test-utils";
 
 let merkleLibTest: Contract;
 
@@ -151,7 +151,7 @@ describe("MerkleLib Proofs", async function () {
     const slowFillLeaves: USSSlowFill[] = [];
     const numDistributions = 101; // Create 101 and remove the last to use as the "invalid" one.
     for (let i = 0; i < numDistributions; i++) {
-      const relayData: USSRelayData = {
+      const relayData: USSFillDepositData = {
         depositor: randomAddress(),
         recipient: randomAddress(),
         exclusiveRelayer: randomAddress(),
@@ -160,7 +160,6 @@ describe("MerkleLib Proofs", async function () {
         inputAmount: randomBigNumber(),
         outputAmount: randomBigNumber(),
         originChainId: randomBigNumber(2).toNumber(),
-        destinationChainId: randomBigNumber(2).toNumber(),
         depositId: BigNumber.from(i).toNumber(),
         fillDeadline: randomBigNumber(2).toNumber(),
         exclusivityDeadline: randomBigNumber(2).toNumber(),
@@ -168,6 +167,7 @@ describe("MerkleLib Proofs", async function () {
       };
       slowFillLeaves.push({
         relayData,
+        chainId: randomBigNumber(2).toNumber(),
         updatedOutputAmount: relayData.outputAmount,
       });
     }

--- a/test/MerkleLib.Proofs.ts
+++ b/test/MerkleLib.Proofs.ts
@@ -13,7 +13,7 @@ import {
   createRandomBytes32,
   ethers,
 } from "../utils/utils";
-import { USSFillDepositData, USSRelayData, USSSlowFill } from "../test-utils";
+import { USSRelayData, USSSlowFill } from "../test-utils";
 
 let merkleLibTest: Contract;
 
@@ -151,7 +151,7 @@ describe("MerkleLib Proofs", async function () {
     const slowFillLeaves: USSSlowFill[] = [];
     const numDistributions = 101; // Create 101 and remove the last to use as the "invalid" one.
     for (let i = 0; i < numDistributions; i++) {
-      const relayData: USSFillDepositData = {
+      const relayData: USSRelayData = {
         depositor: randomAddress(),
         recipient: randomAddress(),
         exclusiveRelayer: randomAddress(),

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -581,19 +581,8 @@ describe("SpokePool Depositor Logic", async function () {
       await expect(spokePool.connect(depositor).depositUSS(...depositArgs)).to.be.revertedWith("Paused deposits");
     });
     it("reentrancy protected", async function () {
-      // In this test we create a reentrancy attempt by sending a fill with a recipient contract that calls back into
-      // the spoke pool via the deposit function.
-      const callbackMessageHandler = await (
-        await getContractFactory("AcrossMessageHandlerCallbackMock", depositor)
-      ).deploy();
       const functionCalldata = spokePool.interface.encodeFunctionData("depositUSS", [...depositArgs]);
-      const _relayData = {
-        ...relayData,
-        outputToken: erc20.address,
-        recipient: callbackMessageHandler.address,
-        message: functionCalldata,
-      };
-      await expect(spokePool.connect(depositor).fillUSSRelay(_relayData, destinationChainId)).to.be.revertedWith(
+      await expect(spokePool.connect(depositor).callback(functionCalldata)).to.be.revertedWith(
         "ReentrancyGuard: reentrant call"
       );
     });

--- a/test/SpokePool.Deposit.ts
+++ b/test/SpokePool.Deposit.ts
@@ -8,13 +8,11 @@ import {
   toWei,
   randomAddress,
   BigNumber,
-  getContractFactory,
 } from "../utils/utils";
 import {
   spokePoolFixture,
   enableRoutes,
   getDepositParams,
-  RelayData,
   USSRelayData,
   getUpdatedUSSDepositSignature,
 } from "./fixtures/SpokePool.Fixture";
@@ -412,7 +410,11 @@ describe("SpokePool Depositor Logic", async function () {
 
   describe("deposit USS", function () {
     let relayData: USSRelayData, depositArgs: any[];
-    function getDepositArgsFromRelayData(_relayData: USSRelayData, _quoteTimestamp = quoteTimestamp) {
+    function getDepositArgsFromRelayData(
+      _relayData: USSRelayData,
+      _destinationChainId = destinationChainId,
+      _quoteTimestamp = quoteTimestamp
+    ) {
       return [
         _relayData.depositor,
         _relayData.recipient,
@@ -420,7 +422,7 @@ describe("SpokePool Depositor Logic", async function () {
         _relayData.outputToken,
         _relayData.inputAmount,
         _relayData.outputAmount,
-        _relayData.destinationChainId,
+        _destinationChainId,
         _relayData.exclusiveRelayer,
         _quoteTimestamp,
         _relayData.fillDeadline,
@@ -438,7 +440,6 @@ describe("SpokePool Depositor Logic", async function () {
         inputAmount: amountToDeposit,
         outputAmount: amountToDeposit.sub(19),
         originChainId: originChainId,
-        destinationChainId: destinationChainId,
         depositId: 0,
         fillDeadline: quoteTimestamp + 1000,
         exclusivityDeadline: 0,
@@ -451,7 +452,7 @@ describe("SpokePool Depositor Logic", async function () {
     });
     it("route disabled", async function () {
       // Verify that routes are disabled by default for a new route
-      const _depositArgs = getDepositArgsFromRelayData({ ...relayData, destinationChainId: 999 });
+      const _depositArgs = getDepositArgsFromRelayData(relayData, 999);
       await expect(spokePool.connect(depositor).depositUSS(..._depositArgs)).to.be.revertedWith("DisabledRoute");
 
       // Enable the route:
@@ -465,13 +466,13 @@ describe("SpokePool Depositor Logic", async function () {
       await expect(
         spokePool.connect(depositor).depositUSS(
           // quoteTimestamp too far into past (i.e. beyond the buffer)
-          ...getDepositArgsFromRelayData(relayData, currentTime.sub(quoteTimeBuffer).sub(1))
+          ...getDepositArgsFromRelayData(relayData, destinationChainId, currentTime.sub(quoteTimeBuffer).sub(1))
         )
       ).to.be.revertedWith("InvalidQuoteTimestamp");
       await expect(
         spokePool.connect(depositor).depositUSS(
           // quoteTimestamp right at the buffer is OK
-          ...getDepositArgsFromRelayData(relayData, currentTime.sub(quoteTimeBuffer))
+          ...getDepositArgsFromRelayData(relayData, destinationChainId, currentTime.sub(quoteTimeBuffer))
         )
       ).to.not.be.reverted;
     });
@@ -533,7 +534,7 @@ describe("SpokePool Depositor Logic", async function () {
           relayData.outputToken,
           relayData.inputAmount,
           relayData.outputAmount,
-          relayData.destinationChainId,
+          destinationChainId,
           // deposit ID is 0 for first deposit
           0,
           quoteTimestamp,
@@ -563,7 +564,7 @@ describe("SpokePool Depositor Logic", async function () {
           relayData.outputToken,
           relayData.inputAmount,
           relayData.outputAmount,
-          relayData.destinationChainId,
+          destinationChainId,
           0,
           quoteTimestamp,
           relayData.fillDeadline,

--- a/test/SpokePool.Relay.ts
+++ b/test/SpokePool.Relay.ts
@@ -22,7 +22,6 @@ import {
   USSRelayExecutionParams,
   FillStatus,
   FillType,
-  USSFillDepositData,
 } from "./fixtures/SpokePool.Fixture";
 import * as consts from "./constants";
 
@@ -31,7 +30,7 @@ let depositor: SignerWithAddress, recipient: SignerWithAddress, relayer: SignerW
 
 // _fillRelay takes a USSRelayExecutionParams object as a param. This function returns the correct object
 // as a convenience.
-async function getRelayExecutionParams(_relayData: USSFillDepositData): Promise<USSRelayExecutionParams> {
+async function getRelayExecutionParams(_relayData: USSRelayData): Promise<USSRelayExecutionParams> {
   const paramType = await getParamType("MockSpokePool", "fillUSSRelay", "relayData");
   return {
     relay: _relayData,
@@ -346,7 +345,7 @@ describe("SpokePool Relayer Logic", async function () {
     await testUpdatedFeeSignatureFailCases(erc1271.address);
   });
   describe("fill USS", function () {
-    let relayData: USSFillDepositData;
+    let relayData: USSRelayData;
     beforeEach(async function () {
       const fillDeadline = (await spokePool.getCurrentTime()).toNumber() + 1000;
       relayData = {

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -15,6 +15,7 @@ import {
   enableRoutes,
   getExecuteSlowRelayParams,
   SlowFill,
+  USSRelayData,
   getUSSRelayHash,
   USSSlowFill,
 } from "./fixtures/SpokePool.Fixture";

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -17,7 +17,6 @@ import {
   SlowFill,
   getUSSRelayHash,
   USSSlowFill,
-  USSFillDepositData,
 } from "./fixtures/SpokePool.Fixture";
 import { getFillRelayParams, getRelayHash } from "./fixtures/SpokePool.Fixture";
 import { MerkleTree } from "../utils/MerkleTree";
@@ -579,7 +578,7 @@ describe("SpokePool Slow Relay Logic", async function () {
   });
 
   describe("requestUSSSlowFill", function () {
-    let relayData: USSFillDepositData;
+    let relayData: USSRelayData;
     beforeEach(async function () {
       const fillDeadline = (await spokePool.getCurrentTime()).toNumber() + 1000;
       relayData = {
@@ -622,7 +621,7 @@ describe("SpokePool Slow Relay Logic", async function () {
     });
   });
   describe("executeUSSSlowRelayLeaf", function () {
-    let relayData: USSFillDepositData, slowRelayLeaf: USSSlowFill;
+    let relayData: USSRelayData, slowRelayLeaf: USSSlowFill;
     beforeEach(async function () {
       const fillDeadline = (await spokePool.getCurrentTime()).toNumber() + 1000;
       relayData = {

--- a/test/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -31,6 +31,7 @@ import {
 } from "../MerkleLib.utils";
 import { randomBytes } from "crypto";
 import {
+  USSRelayData,
   deployMockSpokePoolCaller,
   deployMockUSSSpokePoolCaller,
   getFillRelayParams,

--- a/test/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -31,7 +31,6 @@ import {
 } from "../MerkleLib.utils";
 import { randomBytes } from "crypto";
 import {
-  USSFillDepositData,
   deployMockSpokePoolCaller,
   deployMockUSSSpokePoolCaller,
   getFillRelayParams,
@@ -441,7 +440,7 @@ describe("Polygon Spoke Pool", function () {
         tree.getHexProof(leaves[1]),
       ]),
     ];
-    const relayData: USSFillDepositData = {
+    const relayData: USSRelayData = {
       depositor: owner.address,
       recipient: acrossMessageHandler.address,
       exclusiveRelayer: relayer.address,

--- a/test/chain-specific-spokepools/Polygon_SpokePool.ts
+++ b/test/chain-specific-spokepools/Polygon_SpokePool.ts
@@ -31,6 +31,7 @@ import {
 } from "../MerkleLib.utils";
 import { randomBytes } from "crypto";
 import {
+  USSFillDepositData,
   deployMockSpokePoolCaller,
   deployMockUSSSpokePoolCaller,
   getFillRelayParams,
@@ -440,7 +441,7 @@ describe("Polygon Spoke Pool", function () {
         tree.getHexProof(leaves[1]),
       ]),
     ];
-    const relayData = {
+    const relayData: USSFillDepositData = {
       depositor: owner.address,
       recipient: acrossMessageHandler.address,
       exclusiveRelayer: relayer.address,
@@ -449,7 +450,6 @@ describe("Polygon Spoke Pool", function () {
       inputAmount: toWei("1"),
       outputAmount: toWei("1"),
       originChainId,
-      destinationChainId: l2ChainId,
       depositId: 0,
       fillDeadline: (await polygonSpokePool.getCurrentTime()).toNumber() + 1000,
       exclusivityDeadline: 0,

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -207,8 +207,24 @@ export interface USSRelayData {
   message: string;
 }
 
+// The structure passed into the SpokePool's fillUSS related functions like fillUSSRelay and executeUSSSlowFill.
+export interface USSFillDepositData {
+  depositor: string;
+  recipient: string;
+  exclusiveRelayer: string;
+  inputToken: string;
+  outputToken: string;
+  inputAmount: BigNumber;
+  outputAmount: BigNumber;
+  originChainId: number;
+  depositId: number;
+  fillDeadline: number;
+  exclusivityDeadline: number;
+  message: string;
+}
+
 export interface USSRelayExecutionParams {
-  relay: USSRelayData;
+  relay: USSFillDepositData;
   relayHash: string;
   updatedOutputAmount: BigNumber;
   updatedRecipient: string;
@@ -234,7 +250,8 @@ export interface SlowFill {
 }
 
 export interface USSSlowFill {
-  relayData: USSRelayData;
+  relayData: USSFillDepositData;
+  chainId: number;
   updatedOutputAmount: BigNumber;
 }
 
@@ -274,13 +291,14 @@ export function getRelayHash(
   return { relayHash, relayData };
 }
 
-export function getUSSRelayHash(relayData: USSRelayData): string {
+export function getUSSRelayHash(relayData: USSFillDepositData, destinationChainId: number): string {
   return ethers.utils.keccak256(
     defaultAbiCoder.encode(
       [
-        "tuple(address depositor, address recipient, address exclusiveRelayer, address inputToken, address outputToken, uint256 inputAmount, uint256 outputAmount, uint256 originChainId, uint256 destinationChainId, uint32 depositId, uint32 fillDeadline, uint32 exclusivityDeadline, bytes message)",
+        "tuple(address depositor, address recipient, address exclusiveRelayer, address inputToken, address outputToken, uint256 inputAmount, uint256 outputAmount, uint256 originChainId, uint32 depositId, uint32 fillDeadline, uint32 exclusivityDeadline, bytes message)",
+        "uint256 destinationChainId",
       ],
-      [relayData]
+      [relayData, destinationChainId]
     )
   );
 }

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -200,23 +200,6 @@ export interface USSRelayData {
   inputAmount: BigNumber;
   outputAmount: BigNumber;
   originChainId: number;
-  destinationChainId: number;
-  depositId: number;
-  fillDeadline: number;
-  exclusivityDeadline: number;
-  message: string;
-}
-
-// The structure passed into the SpokePool's fillUSS related functions like fillUSSRelay and executeUSSSlowFill.
-export interface USSFillDepositData {
-  depositor: string;
-  recipient: string;
-  exclusiveRelayer: string;
-  inputToken: string;
-  outputToken: string;
-  inputAmount: BigNumber;
-  outputAmount: BigNumber;
-  originChainId: number;
   depositId: number;
   fillDeadline: number;
   exclusivityDeadline: number;
@@ -224,7 +207,7 @@ export interface USSFillDepositData {
 }
 
 export interface USSRelayExecutionParams {
-  relay: USSFillDepositData;
+  relay: USSRelayData;
   relayHash: string;
   updatedOutputAmount: BigNumber;
   updatedRecipient: string;
@@ -250,7 +233,7 @@ export interface SlowFill {
 }
 
 export interface USSSlowFill {
-  relayData: USSFillDepositData;
+  relayData: USSRelayData;
   chainId: number;
   updatedOutputAmount: BigNumber;
 }
@@ -291,7 +274,7 @@ export function getRelayHash(
   return { relayHash, relayData };
 }
 
-export function getUSSRelayHash(relayData: USSFillDepositData, destinationChainId: number): string {
+export function getUSSRelayHash(relayData: USSRelayData, destinationChainId: number): string {
   return ethers.utils.keccak256(
     defaultAbiCoder.encode(
       [


### PR DESCRIPTION
# Motivation

1. Reduce the number of params passed into fillUSS-related functions by 1 by removing `destinationChainId` from the passed in `struct`. This also has the added safety benefit of not allowing the caller to set the `destinationChainId` and instead forces them to reference a relay hash using the SpokePool's `chainId()`.

2. This additionally saves gas in these functions because it no longer needs to check the input `relayData.destinationChainId` against the contract's `chainId`.

# Side effects:

Changes implementation of how we construct relay hashes for USS fills by now hashing all of the `USSRelayData` params as a struct (i.e. as a DepositData struct) WITH the `chainId()` so that the destinationChainId is still hashed to protect against replay attacks
