### PR TITLE
feat: Add _distributeRelayerRefund unit tests

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1104,11 +1104,7 @@ abstract contract SpokePool is
     ) public virtual override nonReentrant {
         _preExecuteLeafHook(relayerRefundLeaf.l2TokenAddress);
 
-        _validateRelayerRefundLeaf(
-            relayerRefundLeaf.chainId,
-            relayerRefundLeaf.refundAddresses,
-            relayerRefundLeaf.refundAmounts
-        );
+        if (relayerRefundLeaf.chainId != chainId()) revert InvalidChainId();
 
         RootBundle storage rootBundle = rootBundles[rootBundleId];
 
@@ -1154,11 +1150,7 @@ abstract contract SpokePool is
     ) public virtual override nonReentrant {
         _preExecuteLeafHook(relayerRefundLeaf.l2TokenAddress);
 
-        _validateRelayerRefundLeaf(
-            relayerRefundLeaf.chainId,
-            relayerRefundLeaf.refundAddresses,
-            relayerRefundLeaf.refundAmounts
-        );
+        if (relayerRefundLeaf.chainId != chainId()) revert InvalidChainId();
 
         RootBundle storage rootBundle = rootBundles[rootBundleId];
 
@@ -1284,6 +1276,8 @@ abstract contract SpokePool is
         address l2TokenAddress,
         address[] memory refundAddresses
     ) internal {
+        if (refundAddresses.length != refundAmounts.length) revert InvalidMerkleLeaf();
+
         // Send each relayer refund address the associated refundAmount for the L2 token address.
         // Note: Even if the L2 token is not enabled on this spoke pool, we should still refund relayers.
         uint256 length = refundAmounts.length;
@@ -1375,15 +1369,6 @@ abstract contract SpokePool is
 
     // Should be overriden by implementing contract depending on how L2 handles sending tokens to L1.
     function _bridgeTokensToHubPool(uint256 amountToReturn, address l2TokenAddress) internal virtual;
-
-    function _validateRelayerRefundLeaf(
-        uint256 _chainId,
-        address[] memory refundAddresses,
-        uint256[] memory refundAmounts
-    ) internal view {
-        if (_chainId != chainId()) revert InvalidChainId();
-        if (refundAddresses.length != refundAmounts.length) revert InvalidMerkleLeaf();
-    }
 
     function _setClaimedLeaf(uint32 rootBundleId, uint32 leafId) internal {
         RootBundle storage rootBundle = rootBundles[rootBundleId];

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -12,6 +12,8 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
     uint256 private chainId_;
     uint256 private currentTime;
 
+    event BridgedToHubPool(uint256 amount, address token);
+
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(address _wrappedNativeTokenAddress) SpokePool(_wrappedNativeTokenAddress, 1 hours, 9 hours) {} // solhint-disable-line no-empty-blocks
 
@@ -84,8 +86,9 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
         return currentTime;
     }
 
-    // solhint-disable-next-line no-empty-blocks
-    function _bridgeTokensToHubPool(uint256, address) internal override {}
+    function _bridgeTokensToHubPool(uint256 amount, address token) internal override {
+        emit BridgedToHubPool(amount, token);
+    }
 
     function _requireAdminSender() internal override onlyOwner {} // solhint-disable-line no-empty-blocks
 

--- a/test/SpokePool.ExecuteRootBundle.ts
+++ b/test/SpokePool.ExecuteRootBundle.ts
@@ -153,19 +153,20 @@ describe("SpokePool Root Bundle Execution", function () {
     });
   });
 
-  describe.only("_distributeRelayerRefunds", function () {
-    let leaves: USSRelayerRefundLeaf[], tree: MerkleTree<USSRelayerRefundLeaf>;
-    beforeEach(async function () {
-      leaves = buildUSSRelayerRefundLeaves(
-        [destinationChainId, destinationChainId], // Destination chain ID.
-        [consts.amountToReturn, toBN(0)], // amountToReturn.
-        [destErc20.address, destErc20.address], // l2Token.
-        [[], [relayer.address, rando.address, rando.address]], // refundAddresses.
-        [[], [consts.amountToRelay, consts.amountToRelay, toBN(0)]], // refundAmounts.
-        [consts.mockTreeRoot, consts.mockTreeRoot], // fillsRefundedRoot.
-        [consts.mockTreeRoot, consts.mockTreeRoot] // fillsRefundedHash.
-      );
-      tree = await buildUSSRelayerRefundTree(leaves);
+  describe("_distributeRelayerRefunds", function () {
+    it("refund address length mismatch", async function () {
+      await expect(
+        spokePool
+          .connect(dataWorker)
+          .distributeRelayerRefunds(
+            destinationChainId,
+            toBN(1),
+            [consts.amountToRelay, consts.amountToRelay, toBN(0)],
+            0,
+            destErc20.address,
+            [relayer.address, rando.address]
+          )
+      ).to.be.revertedWith("InvalidMerkleLeaf");
     });
     describe("amountToReturn > 0", function () {
       it("calls _bridgeTokensToHubPool", async function () {

--- a/test/SpokePool.ExecuteRootBundle.ts
+++ b/test/SpokePool.ExecuteRootBundle.ts
@@ -1,5 +1,14 @@
 import { MerkleTree } from "../utils/MerkleTree";
-import { SignerWithAddress, seedContract, toBN, expect, Contract, ethers, BigNumber } from "../utils/utils";
+import {
+  SignerWithAddress,
+  seedContract,
+  toBN,
+  expect,
+  Contract,
+  ethers,
+  BigNumber,
+  randomAddress,
+} from "../utils/utils";
 import * as consts from "./constants";
 import { deployMockSpokePoolCaller, spokePoolFixture } from "./fixtures/SpokePool.Fixture";
 import {
@@ -144,28 +153,93 @@ describe("SpokePool Root Bundle Execution", function () {
     });
   });
 
-  describe("Gas test", function () {
-    // Run following tests with REPORT_GAS=true to print out isolated gas costs for internal functions
-    // that are called directly by the MockSpokePool.
-    it("_distributeRelayerRefunds: amountToReturn > 0", async function () {
-      const { leaves, tree } = await constructSimpleTree(destErc20, destinationChainId);
-      await spokePool.connect(dataWorker).relayRootBundle(
-        tree.getHexRoot(), // distribution root. Generated from the merkle tree constructed before.
-        consts.mockSlowRelayRoot
+  describe.only("_distributeRelayerRefunds", function () {
+    let leaves: USSRelayerRefundLeaf[], tree: MerkleTree<USSRelayerRefundLeaf>;
+    beforeEach(async function () {
+      leaves = buildUSSRelayerRefundLeaves(
+        [destinationChainId, destinationChainId], // Destination chain ID.
+        [consts.amountToReturn, toBN(0)], // amountToReturn.
+        [destErc20.address, destErc20.address], // l2Token.
+        [[], [relayer.address, rando.address, rando.address]], // refundAddresses.
+        [[], [consts.amountToRelay, consts.amountToRelay, toBN(0)]], // refundAmounts.
+        [consts.mockTreeRoot, consts.mockTreeRoot], // fillsRefundedRoot.
+        [consts.mockTreeRoot, consts.mockTreeRoot] // fillsRefundedHash.
       );
-
-      const leaf = leaves[0];
-      expect(leaf.amountToReturn).to.be.gt(0);
-      await spokePool
-        .connect(dataWorker)
-        .distributeRelayerRefunds(
-          leaf.chainId,
-          leaf.amountToReturn,
-          leaf.refundAmounts,
-          leaf.leafId,
-          leaf.l2TokenAddress,
-          leaf.refundAddresses
+      tree = await buildUSSRelayerRefundTree(leaves);
+    });
+    describe("amountToReturn > 0", function () {
+      it("calls _bridgeTokensToHubPool", async function () {
+        await expect(
+          spokePool
+            .connect(dataWorker)
+            .distributeRelayerRefunds(destinationChainId, toBN(1), [], 0, destErc20.address, [])
+        )
+          .to.emit(spokePool, "BridgedToHubPool")
+          .withArgs(toBN(1), destErc20.address);
+      });
+      it("emits TokensBridged", async function () {
+        await expect(
+          spokePool
+            .connect(dataWorker)
+            .distributeRelayerRefunds(destinationChainId, toBN(1), [], 0, destErc20.address, [])
+        )
+          .to.emit(spokePool, "TokensBridged")
+          .withArgs(toBN(1), destinationChainId, 0, destErc20.address);
+      });
+    });
+    describe("amountToReturn = 0", function () {
+      it("does not call _bridgeTokensToHubPool", async function () {
+        await expect(
+          spokePool
+            .connect(dataWorker)
+            .distributeRelayerRefunds(destinationChainId, toBN(0), [], 0, destErc20.address, [])
+        ).to.not.emit(spokePool, "BridgedToHubPool");
+      });
+      it("does not emit TokensBridged", async function () {
+        await expect(
+          spokePool
+            .connect(dataWorker)
+            .distributeRelayerRefunds(destinationChainId, toBN(0), [], 0, destErc20.address, [])
+        ).to.not.emit(spokePool, "TokensBridged");
+      });
+    });
+    describe("some refundAmounts > 0", function () {
+      it("sends one Transfer per nonzero refundAmount", async function () {
+        await expect(() =>
+          spokePool
+            .connect(dataWorker)
+            .distributeRelayerRefunds(
+              destinationChainId,
+              toBN(1),
+              [consts.amountToRelay, consts.amountToRelay, toBN(0)],
+              0,
+              destErc20.address,
+              [relayer.address, rando.address, rando.address]
+            )
+        ).to.changeTokenBalances(
+          destErc20,
+          [spokePool, relayer, rando],
+          [consts.amountToRelay.mul(-2), consts.amountToRelay, consts.amountToRelay]
         );
+        const transferLogCount = (await destErc20.queryFilter(destErc20.filters.Transfer(spokePool.address))).length;
+        expect(transferLogCount).to.equal(2);
+      });
+      it("also bridges tokens to hub pool if amountToReturn > 0", async function () {
+        await expect(
+          spokePool
+            .connect(dataWorker)
+            .distributeRelayerRefunds(
+              destinationChainId,
+              toBN(1),
+              [consts.amountToRelay, consts.amountToRelay, toBN(0)],
+              0,
+              destErc20.address,
+              [relayer.address, rando.address, rando.address]
+            )
+        )
+          .to.emit(spokePool, "BridgedToHubPool")
+          .withArgs(toBN(1), destErc20.address);
+      });
     });
   });
 });


### PR DESCRIPTION
Also refactors the SpokePool.sol code so that the validation of merkle leaf properties are done as close to their usage within the logic as possible