### PR TITLE
feat: Add FundsDeposited event for backwards compatible ABI creation

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -167,6 +167,19 @@ abstract contract SpokePool is
     event SetHubPool(address indexed newHubPool);
     event EnabledDepositRoute(address indexed originToken, uint256 indexed destinationChainId, bool enabled);
     /// @custom:audit FOLLOWING EVENT TO BE DEPRECATED
+    event FundsDeposited(
+        uint256 amount,
+        uint256 originChainId,
+        uint256 indexed destinationChainId,
+        int64 relayerFeePct,
+        uint32 indexed depositId,
+        uint32 quoteTimestamp,
+        address originToken,
+        address recipient,
+        address indexed depositor,
+        bytes message
+    );
+    /// @custom:audit FOLLOWING EVENT TO BE DEPRECATED
     event RequestedSpeedUpDeposit(
         int64 newRelayerFeePct,
         uint32 indexed depositId,


### PR DESCRIPTION
This makes unit tests easier in `relayer-v2` to simulate running against a contract that has emitted both `FundsDeposited` and `V3FundsDeposited` events.