### PR TITLE
refactor: Rename fillsRefundedIpfsHash -> fillsRefundedHash

### DIFF
--- a/contracts/interfaces/V3SpokePoolInterface.sol
+++ b/contracts/interfaces/V3SpokePoolInterface.sol
@@ -185,7 +185,7 @@ interface V3SpokePoolInterface {
         address l2TokenAddress,
         address[] refundAddresses,
         bytes32 fillsRefundedRoot,
-        string fillsRefundedIpfsHash
+        string fillsRefundedHash
     );
 
     /**************************************


### PR DESCRIPTION
This is another case of a variable being missed when the naming was changed. The data availability layer isn't bound to IPFS and will probably be something else anyway. This is within the scope of the UMIP, the contracts don't need to be specific about the underlying technology that is used.