### PR TITLE
improve: Restore TokensBridged and ExecutedRelayerRefundLeaf event signatures

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -218,13 +218,15 @@ abstract contract SpokePool is
         uint32 indexed rootBundleId,
         uint32 indexed leafId,
         address l2TokenAddress,
-        address[] refundAddresses
+        address[] refundAddresses,
+        address caller
     );
     event TokensBridged(
         uint256 amountToReturn,
         uint256 indexed chainId,
         uint32 indexed leafId,
-        address indexed l2TokenAddress
+        address indexed l2TokenAddress,
+        address caller
     );
     event EmergencyDeleteRootBundle(uint256 indexed rootBundleId);
     event PausedDeposits(bool isPaused);
@@ -1277,7 +1279,8 @@ abstract contract SpokePool is
             rootBundleId,
             relayerRefundLeaf.leafId,
             relayerRefundLeaf.l2TokenAddress,
-            relayerRefundLeaf.refundAddresses
+            relayerRefundLeaf.refundAddresses,
+            msg.sender
         );
     }
 
@@ -1449,7 +1452,7 @@ abstract contract SpokePool is
         if (amountToReturn > 0) {
             _bridgeTokensToHubPool(amountToReturn, l2TokenAddress);
 
-            emit TokensBridged(amountToReturn, _chainId, leafId, l2TokenAddress);
+            emit TokensBridged(amountToReturn, _chainId, leafId, l2TokenAddress, msg.sender);
         }
     }
 

--- a/test/SpokePool.ExecuteRootBundle.ts
+++ b/test/SpokePool.ExecuteRootBundle.ts
@@ -305,7 +305,7 @@ describe("SpokePool Root Bundle Execution", function () {
             .distributeRelayerRefunds(destinationChainId, toBN(1), [], 0, destErc20.address, [])
         )
           .to.emit(spokePool, "TokensBridged")
-          .withArgs(toBN(1), destinationChainId, 0, destErc20.address);
+          .withArgs(toBN(1), destinationChainId, 0, destErc20.address, dataWorker.address);
       });
     });
     describe("amountToReturn = 0", function () {


### PR DESCRIPTION
We removed these event parameters because they were unused but didn't realize this would inadvertently break clients that query these event signatures. Once contracts are updated, clients wouldn't be able to query historical instances of these events, which is required for the `finalizer` to to finalize remaining withdrawals from deprecated contract versions.