### PR TITLE
improve: L01 Fillers Might Lose Their Collateral

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1127,6 +1127,13 @@ abstract contract SpokePool is
      * then Across will not include a slow fill for the intended deposit.
      */
     function requestV3SlowFill(V3RelayData calldata relayData) public override nonReentrant unpausedFills {
+        // If a depositor has set an exclusivity deadline, then only the exclusive relayer should be able to
+        // fast fill within this deadline. Moreover, the depositor should expect to get *fast* filled within
+        // this deadline, not slow filled. As a simplifying assumption, we will not allow slow fills to be requested
+        // this exclusivity period.
+        if (relayData.exclusivityDeadline >= getCurrentTime()) {
+            revert NoSlowFillsInExclusivityWindow();
+        }
         if (relayData.fillDeadline < getCurrentTime()) revert ExpiredFillDeadline();
 
         bytes32 relayHash = _getV3RelayHash(relayData);

--- a/contracts/interfaces/V3SpokePoolInterface.sol
+++ b/contracts/interfaces/V3SpokePoolInterface.sol
@@ -250,6 +250,7 @@ interface V3SpokePoolInterface {
     error InvalidFillDeadline();
     error MsgValueDoesNotMatchInputAmount();
     error NotExclusiveRelayer();
+    error NoSlowFillsInExclusivityWindow();
     error RelayFilled();
     error InvalidSlowFillRequest();
     error ExpiredFillDeadline();

--- a/test/SpokePool.SlowRelay.ts
+++ b/test/SpokePool.SlowRelay.ts
@@ -599,10 +599,18 @@ describe("SpokePool Slow Relay Logic", async function () {
         exclusivityDeadline: fillDeadline - 500,
         message: "0x",
       };
+      // By default, set current time to after exclusivity deadline
+      await spokePool.setCurrentTime(relayData.exclusivityDeadline + 1);
     });
     it("fill deadline is expired", async function () {
       relayData.fillDeadline = (await spokePool.getCurrentTime()).sub(1);
       await expect(spokePool.connect(relayer).requestV3SlowFill(relayData)).to.be.revertedWith("ExpiredFillDeadline");
+    });
+    it("during exclusivity deadline", async function () {
+      await spokePool.setCurrentTime(relayData.exclusivityDeadline);
+      await expect(spokePool.connect(relayer).requestV3SlowFill(relayData)).to.be.revertedWith(
+        "NoSlowFillsInExclusivityWindow"
+      );
     });
     it("can request before fast fill", async function () {
       const relayHash = getV3RelayHash(relayData, consts.destinationChainId);


### PR DESCRIPTION
Don't permit a slow fill request to be issued when the deposit in                                                                                                                                                                                              
question is still within the specified exclusivity deadline. This                                                                                                                                                                                              
protects deposits where a relayer has made a commitment to fill within                                                                                                                                                                                         
a specified deadline, so they should have the exclusive right to do so. 