### PR TITLE
improve: L06 Inconsistent And Misleading Events Emitted When Bridging To HubPool

### DIFF
--- a/contracts/Arbitrum_SpokePool.sol
+++ b/contracts/Arbitrum_SpokePool.sol
@@ -27,7 +27,6 @@ contract Arbitrum_SpokePool is SpokePool, CircleCCTPAdapter {
     // are necessary params used when bridging tokens to L1.
     mapping(address => address) public whitelistedTokens;
 
-    event ArbitrumTokensBridged(address indexed l1Token, address target, uint256 numberOfTokensBridged);
     event SetL2GatewayRouter(address indexed newL2GatewayRouter);
     event WhitelistedTokens(address indexed l2Token, address indexed l1Token);
 
@@ -107,7 +106,6 @@ contract Arbitrum_SpokePool is SpokePool, CircleCCTPAdapter {
                 "" // _data. We don't need to send any data for the bridging action.
             );
         }
-        emit ArbitrumTokensBridged(address(0), hubPool, amountToReturn);
     }
 
     function _setL2GatewayRouter(address _l2GatewayRouter) internal {

--- a/contracts/Linea_SpokePool.sol
+++ b/contracts/Linea_SpokePool.sol
@@ -105,7 +105,6 @@ contract Linea_SpokePool is SpokePool {
     /**************************************
      *               EVENTS               *
      **************************************/
-    event LineaTokensBridged(address indexed l2Token, address target, uint256 numberOfTokensBridged);
     event SetL2TokenBridge(address indexed newTokenBridge, address oldTokenBridge);
     event SetL2MessageService(address indexed newMessageService, address oldMessageService);
     event SetL2UsdcBridge(address indexed newUsdcBridge, address oldUsdcBridge);
@@ -231,8 +230,6 @@ contract Linea_SpokePool is SpokePool {
             IERC20(l2TokenAddress).safeIncreaseAllowance(address(l2TokenBridge), amountToReturn);
             l2TokenBridge.bridgeToken{ value: msg.value }(l2TokenAddress, amountToReturn, hubPool);
         }
-
-        emit LineaTokensBridged(l2TokenAddress, hubPool, amountToReturn);
     }
 
     function _requireAdminSender() internal view override {

--- a/contracts/Ovm_SpokePool.sol
+++ b/contracts/Ovm_SpokePool.sol
@@ -48,7 +48,6 @@ contract Ovm_SpokePool is SpokePool, CircleCCTPAdapter {
     // to support non-standard ERC20 tokens on Optimism, such as DIA and SNX which both use custom bridges.
     mapping(address => address) public tokenBridges;
 
-    event OptimismTokensBridged(address indexed l2Token, address target, uint256 numberOfTokensBridged, uint256 l1Gas);
     event SetL1Gas(uint32 indexed newL1Gas);
     event SetL2TokenBridge(address indexed l2Token, address indexed tokenBridge);
 
@@ -166,8 +165,6 @@ contract Ovm_SpokePool is SpokePool, CircleCCTPAdapter {
                     l1Gas, // _l1Gas. Unused, but included for potential forward compatibility considerations
                     "" // _data. We don't need to send any data for the bridging action.
                 );
-
-        emit OptimismTokensBridged(l2TokenAddress, hubPool, amountToReturn, l1Gas);
     }
 
     // Apply OVM-specific transformation to cross domain admin address on L1.

--- a/contracts/PolygonZkEVM_SpokePool.sol
+++ b/contracts/PolygonZkEVM_SpokePool.sol
@@ -54,7 +54,6 @@ contract PolygonZkEVM_SpokePool is SpokePool, IBridgeMessageReceiver {
      *               EVENTS               *
      **************************************/
     event SetPolygonZkEVMBridge(address indexed newPolygonZkEVMBridge, address indexed oldPolygonZkEVMBridge);
-    event PolygonZkEVMTokensBridged(address indexed l2Token, address target, uint256 numberOfTokensBridged);
     event ReceivedMessageFromL1(address indexed caller, address indexed originAddress);
 
     // Note: validating calls this way ensures that strange calls coming from the onMessageReceived won't be

--- a/contracts/Polygon_SpokePool.sol
+++ b/contracts/Polygon_SpokePool.sol
@@ -56,7 +56,6 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool, CircleCCTPAdapter 
     bytes32 private constant FILL_LOCK_IDENTIFIER = "Fill";
     bytes32 private constant EXECUTE_LOCK_IDENTIFIER = "Execute";
 
-    event PolygonTokensBridged(address indexed token, address indexed receiver, uint256 amount);
     event SetFxChild(address indexed newFxChild);
     event SetPolygonTokenBridger(address indexed polygonTokenBridger);
     event ReceivedMessageFromL1(address indexed caller, address indexed rootMessageSender);
@@ -247,7 +246,6 @@ contract Polygon_SpokePool is IFxMessageProcessor, SpokePool, CircleCCTPAdapter 
             // Note: WrappedNativeToken is WMATIC on matic, so this tells the tokenbridger that this is an unwrappable native token.
             polygonTokenBridger.send(PolygonIERC20Upgradeable(l2TokenAddress), amountToReturn);
         }
-        emit PolygonTokensBridged(l2TokenAddress, address(this), amountToReturn);
     }
 
     function _wrap() internal {

--- a/contracts/Scroll_SpokePool.sol
+++ b/contracts/Scroll_SpokePool.sol
@@ -27,7 +27,6 @@ contract Scroll_SpokePool is SpokePool {
      *               EVENTS               *
      **************************************/
 
-    event ScrollTokensBridged(address indexed token, address indexed receiver, uint256 amount);
     event SetL2GatewayRouter(address indexed newGatewayRouter, address oldGatewayRouter);
     event SetL2ScrollMessenger(address indexed newScrollMessenger, address oldScrollMessenger);
 
@@ -101,7 +100,6 @@ contract Scroll_SpokePool is SpokePool {
             // See: https://github.com/scroll-tech/scroll/blob/0a8164ee5b63ed5d3bd5e7b39d91445a3176e142/contracts/src/L2/gateways/IL2ERC20Gateway.sol#L69-L80
             0
         );
-        emit ScrollTokensBridged(l2TokenAddress, hubPool, amountToReturn);
     }
 
     /**

--- a/contracts/ZkSync_SpokePool.sol
+++ b/contracts/ZkSync_SpokePool.sol
@@ -33,7 +33,6 @@ contract ZkSync_SpokePool is SpokePool {
     ZkBridgeLike public zkErc20Bridge;
 
     event SetZkBridge(address indexed erc20Bridge, address indexed oldErc20Bridge);
-    event ZkSyncTokensBridged(address indexed l2Token, address target, uint256 numberOfTokensBridged);
 
     /// @custom:oz-upgrades-unsafe-allow constructor
     constructor(
@@ -110,7 +109,6 @@ contract ZkSync_SpokePool is SpokePool {
         } else {
             zkErc20Bridge.withdraw(hubPool, l2TokenAddress, amountToReturn);
         }
-        emit ZkSyncTokensBridged(l2TokenAddress, hubPool, amountToReturn);
     }
 
     function _setZkBridge(ZkBridgeLike _zkErc20Bridge) internal {


### PR DESCRIPTION
These chain-specific bridge events contained some subtle errors, but add                                                                                                                                                                                       
no marginal value over the TokensBridged event emitted in the parent                                                                                                                                                                                           
contract. Remove them because they're not currently used by any known                                                                                                                                                                                          
event consumers and have no identifiable benefit.