### PR TITLE
improve(SpokePool): Delete chainId in ExecutedV3RelayerRefundRoot event

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -1345,7 +1345,6 @@ abstract contract SpokePool is
 
         emit ExecutedV3RelayerRefundRoot(
             relayerRefundLeaf.amountToReturn,
-            relayerRefundLeaf.chainId,
             relayerRefundLeaf.refundAmounts,
             rootBundleId,
             relayerRefundLeaf.leafId,

--- a/contracts/interfaces/V3SpokePoolInterface.sol
+++ b/contracts/interfaces/V3SpokePoolInterface.sol
@@ -178,13 +178,12 @@ interface V3SpokePoolInterface {
 
     event ExecutedV3RelayerRefundRoot(
         uint256 amountToReturn,
-        uint256 indexed chainId,
         uint256[] refundAmounts,
         uint32 indexed rootBundleId,
-        uint32 indexed leafId,
-        address l2TokenAddress,
+        uint32 leafId,
+        address indexed l2TokenAddress,
         address[] refundAddresses,
-        bytes32 fillsRefundedRoot,
+        bytes32 indexed fillsRefundedRoot,
         string fillsRefundedHash
     );
 

--- a/test/SpokePool.ExecuteRootBundle.ts
+++ b/test/SpokePool.ExecuteRootBundle.ts
@@ -261,7 +261,6 @@ describe("SpokePool Root Bundle Execution", function () {
         .to.emit(spokePool, "ExecutedV3RelayerRefundRoot")
         .withArgs(
           leaves[0].amountToReturn,
-          leaves[0].chainId,
           leaves[0].refundAmounts,
           0, // rootBundleId
           leaves[0].leafId,


### PR DESCRIPTION
chainId is not useful because it is known based on the SpokePool being queried. Also, the marginal value of indexing the leafId on top of the rootBundleId is pretty minimal, so instead index l2TokenAddress and fillsRefundedRoot.