### PR TITLE
feat: Update MockSpokePool to include a depositV2 test function

### DIFF
--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -11,6 +11,7 @@ import "@openzeppelin/contracts-upgradeable/access/OwnableUpgradeable.sol";
 contract MockSpokePool is SpokePool, OwnableUpgradeable {
     uint256 private chainId_;
     uint256 private currentTime;
+    using SafeERC20Upgradeable for IERC20Upgradeable;
 
     event BridgedToHubPool(uint256 amount, address token);
     event PreLeafExecuteHook(address token);
@@ -104,5 +105,64 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
 
     function setChainId(uint256 _chainId) public {
         chainId_ = _chainId;
+    }
+
+    // Use this function to unit test that relayer-v2 and sdk-v2 clients can handle FundsDeposited events while also
+    // handling the new V3 events. This function is not explicitly tested in this repository but this contract is
+    // exported and tested in relayer-v2 and sdk-v2 by clients that do contain logic to handle these deprecated
+    // V2 events. After the V3 migration has taken place and there are no more FundsDeposited events queried by
+    // the dataworker and relayer, this function can be deprecated and the V2 unit tests can be removed from
+    // relayer-v2 and sdk-v2.
+    function depositV2(
+        address recipient,
+        address originToken,
+        uint256 amount,
+        uint256 destinationChainId,
+        int64 relayerFeePct,
+        uint32 quoteTimestamp,
+        bytes memory message,
+        uint256 // maxCount
+    ) public payable nonReentrant unpausedDeposits {
+        // // Check that deposit route is enabled.
+        // require(enabledDepositRoutes[originToken][destinationChainId], "Disabled route");
+
+        // // We limit the relay fees to prevent the user spending all their funds on fees.
+        // require(SignedMath.abs(relayerFeePct) < 0.5e18, "Invalid relayer fee");
+        // require(amount <= MAX_TRANSFER_SIZE, "Amount too large");
+
+        // // Require that quoteTimestamp has a maximum age so that depositors pay an LP fee based on recent HubPool usage.
+        // // It is assumed that cross-chain timestamps are normally loosely in-sync, but clock drift can occur. If the
+        // // SpokePool time stalls or lags significantly, it is still possible to make deposits by setting quoteTimestamp
+        // // within the configured buffer. The owner should pause deposits if this is undesirable. This will underflow if
+        // // quoteTimestamp is more than depositQuoteTimeBuffer; this is safe but will throw an unintuitive error.
+
+        // // slither-disable-next-line timestamp
+        // require(getCurrentTime() - quoteTimestamp <= depositQuoteTimeBuffer, "invalid quoteTimestamp");
+
+        // Increment count of deposits so that deposit ID for this spoke pool is unique.
+        uint32 newDepositId = numberOfDeposits++;
+
+        // // If the address of the origin token is a wrappedNativeToken contract and there is a msg.value with the
+        // // transaction then the user is sending ETH. In this case, the ETH should be deposited to wrappedNativeToken.
+        // if (originToken == address(wrappedNativeToken) && msg.value > 0) {
+        //     require(msg.value == amount, "msg.value must match amount");
+        //     wrappedNativeToken.deposit{ value: msg.value }();
+        //     // Else, it is a normal ERC20. In this case pull the token from the user's wallet as per normal.
+        //     // Note: this includes the case where the L2 user has WETH (already wrapped ETH) and wants to bridge them.
+        //     // In this case the msg.value will be set to 0, indicating a "normal" ERC20 bridging action.
+        // } else IERC20Upgradeable(originToken).safeTransferFrom(msg.sender, address(this), amount);
+
+        emit FundsDeposited(
+            amount,
+            chainId(),
+            destinationChainId,
+            relayerFeePct,
+            newDepositId,
+            quoteTimestamp,
+            originToken,
+            recipient,
+            msg.sender,
+            message
+        );
     }
 }

--- a/contracts/test/MockSpokePool.sol
+++ b/contracts/test/MockSpokePool.sol
@@ -123,34 +123,34 @@ contract MockSpokePool is SpokePool, OwnableUpgradeable {
         bytes memory message,
         uint256 // maxCount
     ) public payable nonReentrant unpausedDeposits {
-        // // Check that deposit route is enabled.
-        // require(enabledDepositRoutes[originToken][destinationChainId], "Disabled route");
+        // Check that deposit route is enabled.
+        require(enabledDepositRoutes[originToken][destinationChainId], "Disabled route");
 
-        // // We limit the relay fees to prevent the user spending all their funds on fees.
-        // require(SignedMath.abs(relayerFeePct) < 0.5e18, "Invalid relayer fee");
-        // require(amount <= MAX_TRANSFER_SIZE, "Amount too large");
+        // We limit the relay fees to prevent the user spending all their funds on fees.
+        require(SignedMath.abs(relayerFeePct) < 0.5e18, "Invalid relayer fee");
+        require(amount <= MAX_TRANSFER_SIZE, "Amount too large");
 
-        // // Require that quoteTimestamp has a maximum age so that depositors pay an LP fee based on recent HubPool usage.
-        // // It is assumed that cross-chain timestamps are normally loosely in-sync, but clock drift can occur. If the
-        // // SpokePool time stalls or lags significantly, it is still possible to make deposits by setting quoteTimestamp
-        // // within the configured buffer. The owner should pause deposits if this is undesirable. This will underflow if
-        // // quoteTimestamp is more than depositQuoteTimeBuffer; this is safe but will throw an unintuitive error.
+        // Require that quoteTimestamp has a maximum age so that depositors pay an LP fee based on recent HubPool usage.
+        // It is assumed that cross-chain timestamps are normally loosely in-sync, but clock drift can occur. If the
+        // SpokePool time stalls or lags significantly, it is still possible to make deposits by setting quoteTimestamp
+        // within the configured buffer. The owner should pause deposits if this is undesirable. This will underflow if
+        // quoteTimestamp is more than depositQuoteTimeBuffer; this is safe but will throw an unintuitive error.
 
-        // // slither-disable-next-line timestamp
-        // require(getCurrentTime() - quoteTimestamp <= depositQuoteTimeBuffer, "invalid quoteTimestamp");
+        // slither-disable-next-line timestamp
+        require(getCurrentTime() - quoteTimestamp <= depositQuoteTimeBuffer, "invalid quoteTimestamp");
 
         // Increment count of deposits so that deposit ID for this spoke pool is unique.
         uint32 newDepositId = numberOfDeposits++;
 
-        // // If the address of the origin token is a wrappedNativeToken contract and there is a msg.value with the
-        // // transaction then the user is sending ETH. In this case, the ETH should be deposited to wrappedNativeToken.
-        // if (originToken == address(wrappedNativeToken) && msg.value > 0) {
-        //     require(msg.value == amount, "msg.value must match amount");
-        //     wrappedNativeToken.deposit{ value: msg.value }();
-        //     // Else, it is a normal ERC20. In this case pull the token from the user's wallet as per normal.
-        //     // Note: this includes the case where the L2 user has WETH (already wrapped ETH) and wants to bridge them.
-        //     // In this case the msg.value will be set to 0, indicating a "normal" ERC20 bridging action.
-        // } else IERC20Upgradeable(originToken).safeTransferFrom(msg.sender, address(this), amount);
+        // If the address of the origin token is a wrappedNativeToken contract and there is a msg.value with the
+        // transaction then the user is sending ETH. In this case, the ETH should be deposited to wrappedNativeToken.
+        if (originToken == address(wrappedNativeToken) && msg.value > 0) {
+            require(msg.value == amount, "msg.value must match amount");
+            wrappedNativeToken.deposit{ value: msg.value }();
+            // Else, it is a normal ERC20. In this case pull the token from the user's wallet as per normal.
+            // Note: this includes the case where the L2 user has WETH (already wrapped ETH) and wants to bridge them.
+            // In this case the msg.value will be set to 0, indicating a "normal" ERC20 bridging action.
+        } else IERC20Upgradeable(originToken).safeTransferFrom(msg.sender, address(this), amount);
 
         emit FundsDeposited(
             amount,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.5.0-beta.4.2",
+  "version": "2.5.0-beta.4",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.5.0-beta.3",
+  "version": "2.5.0-beta.4",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.5.0-beta.4",
+  "version": "2.5.0-beta.4.2",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {

--- a/test/fixtures/SpokePool.Fixture.ts
+++ b/test/fixtures/SpokePool.Fixture.ts
@@ -80,7 +80,7 @@ export async function enableRoutes(spokePool: Contract, routes: DepositRoute[]) 
   }
 }
 
-export async function deposit(
+export async function depositV2(
   spokePool: Contract,
   token: Contract,
   recipient: SignerWithAddress,
@@ -91,7 +91,7 @@ export async function deposit(
   quoteTimestamp?: number,
   message?: string
 ): Promise<Record<string, number | BigNumber | string> | null> {
-  await spokePool.connect(depositor).deposit(
+  await spokePool.connect(depositor).depositV2(
     ...getDepositParams({
       recipient: recipient.address,
       originToken: token.address,
@@ -103,7 +103,7 @@ export async function deposit(
     })
   );
   const [events, originChainId] = await Promise.all([
-    spokePool.queryFilter(spokePool.filters.V3FundsDeposited()),
+    spokePool.queryFilter(spokePool.filters.FundsDeposited()),
     spokePool.chainId(),
   ]);
 


### PR DESCRIPTION
Currently,  sdk-v2 and relayer-v2 use this repo's test-util.ts export for their unit tests, which tests against this repo's MockSpokePool. Some of these functions will fail because the existing 
MockSpokePool doesn't have any way to emit FundsDeposited events, which these functions query for.
