### PR TITLE
chore: Bump beta again

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.5.0-beta.6",
+  "version": "2.5.0-beta.7",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
npm already had 2.5.0-beta.6 and 2.5.0-beta6.1. Have resolved why they were there, so bump to 2.5.0-beta.7.