### PR TITLE
fix: Remove duplicate events from Sepolia ABIs

### DIFF
--- a/deployments/base-sepolia/Base_SpokePool.json
+++ b/deployments/base-sepolia/Base_SpokePool.json
@@ -574,37 +574,6 @@
       "anonymous": false,
       "inputs": [
         {
-          "indexed": true,
-          "internalType": "address",
-          "name": "l2Token",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "target",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "numberOfTokensBridged",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "l1Gas",
-          "type": "uint256"
-        }
-      ],
-      "name": "OptimismTokensBridged",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
           "indexed": false,
           "internalType": "bool",
           "name": "isPaused",
@@ -2220,19 +2189,6 @@
     {
       "inputs": [],
       "name": "l2Eth",
-      "outputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "messenger",
       "outputs": [
         {
           "internalType": "address",

--- a/deployments/sepolia/Ethereum_SpokePool.json
+++ b/deployments/sepolia/Ethereum_SpokePool.json
@@ -238,49 +238,6 @@
         {
           "indexed": false,
           "internalType": "uint256",
-          "name": "amountToReturn",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "chainId",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256[]",
-          "name": "refundAmounts",
-          "type": "uint256[]"
-        },
-        {
-          "indexed": true,
-          "internalType": "uint32",
-          "name": "rootBundleId",
-          "type": "uint32"
-        },
-        {
-          "indexed": true,
-          "internalType": "uint32",
-          "name": "leafId",
-          "type": "uint32"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "caller",
-          "type": "address"
-        }
-      ],
-      "name": "ExecutedRelayerRefundRoot",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
           "name": "amount",
           "type": "uint256"
         },
@@ -709,49 +666,6 @@
         }
       ],
       "name": "RequestedSpeedUpDeposit",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "updatedOutputAmount",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "uint32",
-          "name": "depositId",
-          "type": "uint32"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "depositor",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "address",
-          "name": "updatedRecipient",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "updatedMessage",
-          "type": "bytes"
-        },
-        {
-          "indexed": false,
-          "internalType": "bytes",
-          "name": "depositorSignature",
-          "type": "bytes"
-        }
-      ],
-      "name": "RequestedSpeedUpV3Deposit",
       "type": "event"
     },
     {


### PR DESCRIPTION
These were introduced as a result of a bad merge. They're testnet deployments only; the production deployments were merged separately by Nick.