### PR TITLE
fix: remove hardhat from standard import

### DIFF
--- a/utils/index.ts
+++ b/utils/index.ts
@@ -1,3 +1,2 @@
-export * from "./utils";
 export * from "./MerkleTree";
 export * from "./constants";


### PR DESCRIPTION
This PR will remove hardhat from the standard import path. This means that ts/js code that does:
```
import ... from "@across-protocol/contracts-v2"
```

will not need a hardhat config and will not spin up a local hardhat node by default. I've verified that the files in utils don't seem to be used in sdk-v2 or relayer-v2.

I think this was accidentally moved into our production exports in a larger change: https://github.com/across-protocol/contracts-v2/pull/272.