### PR TITLE
chore(V2): revert events

### DIFF
--- a/contracts/SpokePool.sol
+++ b/contracts/SpokePool.sol
@@ -182,6 +182,68 @@ abstract contract SpokePool is
     event PausedDeposits(bool isPaused);
     event PausedFills(bool isPaused);
 
+    /// EVENTS BELOW ARE DEPRECATED AND EXIST FOR BACKWARDS COMPATIBILITY ONLY.
+    /// @custom:audit FOLLOWING EVENT TO BE DEPRECATED
+    event FundsDeposited(
+        uint256 amount,
+        uint256 originChainId,
+        uint256 indexed destinationChainId,
+        int64 relayerFeePct,
+        uint32 indexed depositId,
+        uint32 quoteTimestamp,
+        address originToken,
+        address recipient,
+        address indexed depositor,
+        bytes message
+    );
+    /// @custom:audit FOLLOWING EVENT TO BE DEPRECATED
+    event RequestedSpeedUpDeposit(
+        int64 newRelayerFeePct,
+        uint32 indexed depositId,
+        address indexed depositor,
+        address updatedRecipient,
+        bytes updatedMessage,
+        bytes depositorSignature
+    );
+    /// @custom:audit FOLLOWING EVENT TO BE DEPRECATED
+    event FilledRelay(
+        uint256 amount,
+        uint256 totalFilledAmount,
+        uint256 fillAmount,
+        uint256 repaymentChainId,
+        uint256 indexed originChainId,
+        uint256 destinationChainId,
+        int64 relayerFeePct,
+        int64 realizedLpFeePct,
+        uint32 indexed depositId,
+        address destinationToken,
+        address relayer,
+        address indexed depositor,
+        address recipient,
+        bytes message,
+        RelayExecutionInfo updatableRelayData
+    );
+    /**
+     * @notice Packs together information to include in FilledRelay event.
+     * @dev This struct is emitted as opposed to its constituent parameters due to the limit on number of
+     * parameters in an event.
+     * @param recipient Recipient of the relayed funds.
+     * @param message Message included in the relay.
+     * @param relayerFeePct Relayer fee pct used for this relay.
+     * @param isSlowRelay Whether this is a slow relay.
+     * @param payoutAdjustmentPct Adjustment to the payout amount.
+     */
+    /// @custom:audit FOLLOWING STRUCT TO BE DEPRECATED
+    struct RelayExecutionInfo {
+        address recipient;
+        bytes message;
+        int64 relayerFeePct;
+        bool isSlowRelay;
+        int256 payoutAdjustmentPct;
+    }
+
+    /// EVENTS ABOVE ARE DEPRECATED AND EXIST FOR BACKWARDS COMPATIBILITY ONLY.
+
     /**
      * @notice Construct the SpokePool. Normally, logic contracts used in upgradeable proxies shouldn't
      * have constructors since the following code will be executed within the logic contract's state, not the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@across-protocol/contracts-v2",
-  "version": "2.5.1",
+  "version": "2.5.2",
   "author": "UMA Team",
   "license": "AGPL-3.0-only",
   "repository": {


### PR DESCRIPTION
This PR aims at returning the V2 events for FilledRelay, FundsDeposited, and RequestedSpeedUpDeposit. After an internal discussion with @nicholaspai and @pxrl this feels like the lowest lift to push the deployments forward without having to make large changes to the SDK.